### PR TITLE
feat(#14): JSON-driven CapabilityBinder + wire Canvas drag via binder; expand ADR-0002

### DIFF
--- a/core/binder/CapabilityBinder.js
+++ b/core/binder/CapabilityBinder.js
@@ -1,0 +1,45 @@
+const path = require("path");
+const fs = require("fs");
+
+let __defaultsCache = null;
+function getDefaults() {
+  if (__defaultsCache) return __defaultsCache;
+  try {
+    const p = path.resolve(__dirname, "../registry/defaults.json");
+    const raw = fs.readFileSync(p, "utf8");
+    __defaultsCache = JSON.parse(raw);
+    return __defaultsCache;
+  } catch {
+    __defaultsCache = { "*": {} };
+    return __defaultsCache;
+  }
+}
+
+function resolvePluginId(node, capability) {
+  const type = node?.component?.metadata?.type;
+  const behaviors = node?.component?.behaviors || {};
+  const explicit = behaviors?.[capability]?.plugin;
+  if (explicit && typeof explicit === "string") return explicit;
+
+  const defaults = getDefaults();
+  if (type && defaults[type] && defaults[type][capability])
+    return defaults[type][capability];
+  if (defaults["*"] && defaults["*"][capability])
+    return defaults["*"][capability];
+  return null;
+}
+
+async function play(conductor, node, capability, payload = {}) {
+  const id = resolvePluginId(node, capability);
+  if (!id)
+    throw new Error(`No plugin id resolved for capability '${capability}'`);
+  const config = node?.component?.behaviors?.[capability]?.config;
+  const finalPayload = {
+    ...payload,
+    ...(config ? { config } : {}),
+    nodeId: node?.id,
+  };
+  return conductor.play(id, id, finalPayload);
+}
+
+module.exports = { resolvePluginId, play };

--- a/core/registry/defaults.json
+++ b/core/registry/defaults.json
@@ -1,0 +1,23 @@
+{
+  "button": {
+    "drag": "Canvas.component-drag-symphony",
+    "resize": "Canvas.component-resize-symphony",
+    "overlay": "Canvas.ui-symphony",
+    "select": "Canvas.component-select-symphony"
+  },
+  "input": {
+    "drag": "Canvas.component-drag-symphony",
+    "resize": "Canvas.component-resize-symphony",
+    "overlay": "Canvas.ui-symphony",
+    "select": "Canvas.component-select-symphony"
+  },
+  "line": {
+    "drag": "Canvas.component-drag-symphony",
+    "resize": "Canvas.component-resize-symphony",
+    "overlay": "Canvas.ui-symphony",
+    "select": "Canvas.component-select-symphony"
+  },
+  "*": {
+    "select": "Canvas.component-select-symphony"
+  }
+}

--- a/docs/adr/ADR-0001-orchestral-architecture.md
+++ b/docs/adr/ADR-0001-orchestral-architecture.md
@@ -1,6 +1,6 @@
 # ADR-0001: Orchestral Architecture for Scalable Plugins
 
-- Status: Proposed
+- Status: Superseded by ADR-0002
 - Date: 2025-08-16
 - Owners: Plugin Architecture Working Group
 - Related: Musical Conductor pattern; QA Theme Symphony tests

--- a/docs/adr/ADR-0002-json-driven-capability-bindings.md
+++ b/docs/adr/ADR-0002-json-driven-capability-bindings.md
@@ -1,0 +1,218 @@
+# ADR-0002: JSON-driven Capability Bindings for Component Behavior
+
+- Status: Proposed
+- Date: 2025-08-17
+- Owners: Plugin Architecture Working Group
+- Related: ADR-0001 Orchestral Architecture (superseded by this ADR); Issue #14
+
+## Context
+
+We want component behavior to be component-agnostic in plugins, with components themselves declaring which plugins should drive their capabilities (drag, resize, overlay, selection, etc.). This avoids coupling plugins to component types and supports variation (e.g., Line vs Button resize) without branching inside plugins.
+
+The system already uses the Musical Conductor pattern (play/callback) and a shared store (Prompt Book). We need a resolution layer that:
+
+- Reads bindings from component JSON
+- Falls back to type defaults and wildcard defaults
+- Calls the selected plugin via conductor.play using stable plugin IDs from the manifest
+- Keeps plugins ignorant of component types
+
+## Decision
+
+Introduce JSON-driven capability bindings with a thin runtime resolver (CapabilityBinder):
+
+- Each component JSON may specify `behaviors` mapping capability → binding:
+  - `behaviors.<capability>.plugin`: The plugin ID (manifest name/Conductor sequence id)
+  - `behaviors.<capability>.config` (optional): Arbitrary config passed to the plugin payload
+- The CapabilityBinder resolves the plugin ID given `(node, capability)` using precedence:
+  1. Instance-level: `node.component.behaviors?.[capability]?.plugin`
+  2. Type default: `defaults[ node.component.metadata.type ][ capability ]`
+  3. Wildcard default: `defaults["*"][ capability ]`
+  4. Otherwise: error (fail fast in dev/test)
+- Orchestration uses the selected plugin ID as both channel and sequence id:
+  - `conductor.play(pluginId, pluginId, payload)`
+  - Phases remain in payload (e.g., `{ phase: "start" }`), never as sequence IDs
+
+## Alignment with Architecture Vision
+
+This decision makes the orchestration model explicitly component-agnostic and JSON-driven, aligning to the vision in four dimensions:
+
+1. Capability ownership and isolation
+
+- Each capability plugin owns its end-to-end behavior (inputs via Conductor, rules in Arrangements, side-effects in StageCrew, state in Prompt Book).
+- Plugins do not know component types; component JSON binds capabilities to plugins.
+
+2. Composability: use cases, profiles, solutions
+
+- Profiles: curated defaults for a use case (e.g., forms-basic, diagramming). Resolution order extends to: instance → profile → type → wildcard.
+- Solutions: bundles of profiles with pinned plugin versions for a product line; optional lockfiles for reproducibility.
+- Domain registries: as domains grow, defaults/profiles can be published as packages and merged at runtime.
+
+3. Telemetry and monitoring
+
+- Conductor is a single entry point, so play(channel=id, id, payload) produces structured, comparable events across capabilities.
+- Payload includes nodeId, capability, and optional config → easy to aggregate by capability/plugin/component type.
+- Add a lightweight TelemetryAdapter that observes play() calls (or wraps conductor.play) to emit traces/metrics (duration, error counts, frequency by capability, top configs).
+- Prompt Book actions/selectors provide another surface for measuring state changes.
+
+4. Test strategy (BDD-aligned)
+
+- Rehearsals reflect behavior-driven scenarios: Given component JSON binding X, When capability Y is played, Then state/visuals match Z.
+- Layers of tests:
+  - Unit: CapabilityBinder resolution precedence (+ profile context)
+  - Contract: plugins use Conductor + Prompt Book only (no cross-coupling)
+  - Capability rehearsals: drag/resize/overlay/selection per plugin variant
+  - Use-case rehearsals: profile-level flows (e.g., forms-basic across multiple components)
+  - E2E flows: solution-level scenarios with pinned plugin versions
+
+## Telemetry Adapter Sketch
+
+```ts
+// core/telemetry/TelemetryAdapter.ts
+export function wrapConductor(conductor, emitter) {
+  const play = conductor.play.bind(conductor);
+  conductor.play = async (channel, id, payload) => {
+    const t0 = performance.now();
+    try {
+      const res = await play(channel, id, payload);
+      emitter.emit("capability.play", {
+        channel,
+        id,
+        duration: performance.now() - t0,
+        ok: true,
+        capability: payload?.capability,
+        nodeId: payload?.nodeId,
+      });
+      return res;
+    } catch (err) {
+      emitter.emit("capability.play", {
+        channel,
+        id,
+        duration: performance.now() - t0,
+        ok: false,
+        error: String(err),
+        capability: payload?.capability,
+        nodeId: payload?.nodeId,
+      });
+      throw err;
+    }
+  };
+  return conductor;
+}
+```
+
+## Resolution Precedence (with profiles)
+
+1. component.behaviors[capability].plugin
+2. profileDefaults[type][capability]
+3. typeDefaults[type][capability]
+4. wildcardDefaults["\*"][capability]
+5. otherwise: error
+
+## Migration Notes
+
+- Start with defaults in-repo; extract to packages as domains grow
+- Keep manifest “name” as the canonical plugin id used by JSON + Conductor
+- Maintain test-safe fallbacks during migration; remove once all flows are concertmaster-driven
+
+## Consequences
+
+- Plugins remain component-agnostic; they implement capabilities and operate via Prompt Book
+- Component JSONs (and defaults) decide which plugin drives a capability
+- Cross-capability effects (e.g., overlay reacting to drag) happen through Prompt Book (state → selector), not direct calls between plugins
+- We gain flexibility to introduce variants (e.g., `Canvas.resize.line-symphony`) and bind them per component
+
+## Alternatives Considered
+
+- Hardcoding plugin IDs in handlers: brittle and blocks per-component variation
+- Making plugins aware of component types: couples domain concerns into plugins and increases branching
+
+## Architecture and File Structure
+
+- core/
+  - binder/
+    - CapabilityBinder.(ts|js) — resolve + play helper
+  - registry/
+    - defaults.json — type → capability → pluginId
+    - profiles/ (future) — use-case profiles
+- components/
+  - library/
+    - <component>.component.json — includes `metadata` and `behaviors`
+- plugins/
+  - manifest.json — authoritative plugin ids
+  - capabilities/
+    - drag/_, resize/_, overlay/_, selection/_ (variants as separate plugins)
+
+## JSON Schemas (future work)
+
+- `docs/schema/component.schema.json`: validates `metadata` and `behaviors`
+- `docs/schema/registry.schema.json`: validates defaults/profiles
+- CI step to validate all component JSONs and registries
+
+## Example
+
+Component JSON (Button):
+
+```json
+{
+  "metadata": { "type": "button", "name": "Button" },
+  "behaviors": {
+    "drag": { "plugin": "Canvas.component-drag-symphony" },
+    "resize": { "plugin": "Canvas.component-resize-symphony" },
+    "overlay": { "plugin": "Canvas.ui-symphony" },
+    "select": { "plugin": "Canvas.component-select-symphony" }
+  }
+}
+```
+
+Type defaults (excerpt):
+
+```json
+{
+  "button": {
+    "drag": "Canvas.component-drag-symphony",
+    "select": "Canvas.component-select-symphony"
+  },
+  "*": {
+    "select": "Canvas.component-select-symphony"
+  }
+}
+```
+
+## Runtime Contract
+
+- Binder:
+  - `resolvePluginId(node, capability) -> string | null`
+  - `play(conductor, node, capability, payload) -> Promise<void>`
+  - Merges payload with `config` from JSON when present, and includes `nodeId`
+- Handlers/Concertmasters call binder.play for capability routing
+
+## Profiles and Solutions (evolution path)
+
+To scale configuration without coupling, we will support:
+
+- Profiles — curated defaults for a use case (e.g., `forms-basic`)
+  - Resolution adds a profile layer between instance and type defaults
+- Solutions — productized bundles of profiles and pinned plugin versions
+
+These are additive and do not change the core decision.
+
+## Testing Strategy
+
+- Rehearsals for binder resolution (explicit, type default, wildcard, error)
+- Flow tests proving Canvas UI uses binder for capability routing
+- Contract tests that plugins:
+  - Use Conductor + Prompt Book only
+  - Do not depend on component types
+
+## Rollout Plan
+
+1. Land CapabilityBinder + defaults.json with tests
+2. Wire Canvas drag through the binder (no behavior change)
+3. Add component JSONs and migrate overlay/selection
+4. Introduce a line-specific resize plugin and bind it in Line JSON
+5. Add schema validation in CI
+
+## Status Tracking
+
+- PR: feat(#14) Orchestral architecture migration + JSON-driven bindings
+- This ADR will be revised as we add profiles/solutions and more capabilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "renderx-plugins",
+  "name": "@bpmsoftwaresolutions/renderx-plugins",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "renderx-plugins",
+      "name": "@bpmsoftwaresolutions/renderx-plugins",
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,37 @@
 {
-  "name": "renderx-plugins",
-  "version": "0.1.0",
-  "private": true,
+  "name": "@bpmsoftwaresolutions/renderx-plugins",
+  "version": "1.0.0",
   "description": "RenderX plugins meta-package with unit tests and build + manifest generation",
   "license": "MIT",
   "type": "commonjs",
+  "main": "dist/manifest.json",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BPMSoftwareSolutions/renderx-plugins.git"
+  },
+  "bugs": {
+    "url": "https://github.com/BPMSoftwareSolutions/renderx-plugins/issues"
+  },
+  "homepage": "https://github.com/BPMSoftwareSolutions/renderx-plugins#readme",
+  "keywords": [
+    "renderx",
+    "plugins",
+    "musical-conductor"
+  ],
   "scripts": {
     "test": "jest --passWithNoTests",
     "test:ci": "jest --ci",
     "build:plugins": "node ./scripts/build-plugins.mjs",
     "build:manifest": "node ./scripts/generate-manifest.mjs",
-    "build": "npm run build:plugins && npm run build:manifest"
+    "build": "npm run build:plugins && npm run build:manifest",
+    "prepack": "npm run build"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/plugins/canvas-ui-plugin/bootstrap/concertmasters.bootstrap.ts
+++ b/plugins/canvas-ui-plugin/bootstrap/concertmasters.bootstrap.ts
@@ -1,0 +1,117 @@
+// Bootstrap: registers Canvas concertmasters with the Conductor using the Prompt Book
+// Note: Uses conductor.on/off if present; otherwise, falls back to subscribe/unsubscribe
+
+import { canvasPromptBook } from "../state/canvas.prompt-book";
+import { dragArrangement } from "../features/drag/drag.arrangement";
+import { registerDragConcertmaster } from "../features/drag/drag.concertmaster";
+import { registerSelectionConcertmaster } from "../features/selection/selection.concertmaster";
+import { registerOverlayConcertmaster } from "../features/overlay/overlay.concertmaster";
+
+export type ConductorLike = {
+  play: (
+    pluginId: string,
+    sequenceId: string,
+    context?: any,
+    priority?: any
+  ) => any;
+  on?: (
+    channel: string,
+    action: string,
+    handler: (payload: any) => void
+  ) => any;
+  off?: (
+    channel: string,
+    action: string,
+    handler: (payload: any) => void
+  ) => any;
+  subscribe?: (
+    eventName: string,
+    cb: (payload: any) => void,
+    context?: any
+  ) => any;
+  unsubscribe?: (eventName: string, cb: (payload: any) => void) => void;
+};
+
+function makeConductorAdapter(conductor: ConductorLike) {
+  const hasOn = typeof (conductor as any).on === "function";
+  const hasSub = typeof (conductor as any).subscribe === "function";
+  if (hasOn) return conductor as any;
+  if (!hasSub) {
+    throw new Error("Conductor must expose on/off or subscribe/unsubscribe");
+  }
+  // Adapt subscribe/unsubscribe to support action-phase filtering using payload
+  return {
+    play: (conductor as any).play.bind(conductor),
+    on(channel: string, action: string, handler: (payload: any) => void) {
+      const eventName = `${channel}:${action}`;
+      // Subscribe to explicit name if emitter uses namespaced events
+      const unsub1 = (conductor.subscribe as any)(eventName, handler);
+      // Also subscribe to base channel and filter by payload shape when phases are not in event name
+      const phaseGuard = (p: any) => {
+        if (action === "start" && p?.origin != null) return handler(p);
+        if (action === "update" && p?.delta != null) return handler(p);
+        if (action === "end" && (p?.end === true || p?.onDragEnd))
+          return handler(p);
+      };
+      const unsub2 = (conductor.subscribe as any)(channel, phaseGuard);
+      return () => {
+        try {
+          unsub1 && unsub1();
+        } catch {}
+        try {
+          unsub2 && unsub2();
+        } catch {}
+      };
+    },
+    off(channel: string, action: string, handler: (payload: any) => void) {
+      const eventName = `${channel}:${action}`;
+      try {
+        (conductor.unsubscribe as any)(eventName, handler);
+      } catch {}
+      // No-op for the base channel guard; it will be removed by the returned function from on()
+    },
+  } as ConductorLike & { on: any; off: any };
+}
+
+export function registerCanvasConcertmasters(
+  conductor: ConductorLike,
+  deps?: { store?: any }
+) {
+  const cx = makeConductorAdapter(conductor);
+  const store = deps?.store || canvasPromptBook;
+
+  // Drag
+  registerDragConcertmaster(cx as any, { store, dragArrangement });
+
+  // Selection
+  registerSelectionConcertmaster(cx as any, { store });
+
+  // Overlay (uses cssAdapter via DOM)
+  const cssAdapter = {
+    upsertStyle(id: string, css: string) {
+      try {
+        const d = (typeof document !== "undefined" && document) || null;
+        if (!d) return;
+        let el = d.getElementById(id) as HTMLStyleElement | null;
+        if (!el) {
+          el = d.createElement("style");
+          el.id = id;
+          d.head.appendChild(el);
+        }
+        if (el) el.textContent = css;
+      } catch {}
+    },
+    removeStyle(id: string) {
+      try {
+        const d = (typeof document !== "undefined" && document) || null;
+        if (!d) return;
+        const el = d.getElementById(id);
+        if (el && el.parentNode) el.parentNode.removeChild(el);
+      } catch {}
+    },
+  };
+  registerOverlayConcertmaster(cx as any, { store, cssAdapter });
+
+  // Future: resize
+  // registerResizeConcertmaster(cx as any, { store, resizeArrangement });
+}

--- a/plugins/canvas-ui-plugin/core/CanvasPage.js
+++ b/plugins/canvas-ui-plugin/core/CanvasPage.js
@@ -109,6 +109,26 @@ export function CanvasPage(props = {}) {
     } catch {}
   }, []);
 
+  // Sync Prompt Book when nodes prop changes (keeps baselines fresh after library drop)
+  useEffect(() => {
+    try {
+      const w = (typeof window !== "undefined" && window) || {};
+      const pb = w.__rx_prompt_book__;
+      if (pb && Array.isArray(providedNodes)) {
+        pb.actions?.setNodes?.(providedNodes);
+      }
+    } catch {}
+  }, [providedNodes]);
+
+  // Sync Prompt Book when selectedId changes
+  useEffect(() => {
+    try {
+      const w = (typeof window !== "undefined" && window) || {};
+      const pb = w.__rx_prompt_book__;
+      if (pb) pb.actions?.select?.(providedSelected ?? null);
+    } catch {}
+  }, [providedSelected]);
+
   useEffect(() => {
     // Expose UI setters for conductor callback wiring; not a global listener
     try {

--- a/plugins/canvas-ui-plugin/features/drag/drag.arrangement.ts
+++ b/plugins/canvas-ui-plugin/features/drag/drag.arrangement.ts
@@ -1,0 +1,11 @@
+// Drag Arrangement (Service): pure position math
+export const dragArrangement = {
+  applyDelta(current: { x?: number; y?: number } = {}, delta: { dx?: number; dy?: number } = {}) {
+    const x0 = typeof current.x === 'number' ? current.x : 0;
+    const y0 = typeof current.y === 'number' ? current.y : 0;
+    const dx = typeof delta.dx === 'number' ? delta.dx : 0;
+    const dy = typeof delta.dy === 'number' ? delta.dy : 0;
+    return { x: x0 + dx, y: y0 + dy };
+  },
+};
+

--- a/plugins/canvas-ui-plugin/features/drag/drag.concertmaster.ts
+++ b/plugins/canvas-ui-plugin/features/drag/drag.concertmaster.ts
@@ -1,0 +1,28 @@
+// Drag Concertmaster (Controller): orchestrates drag symphony
+import type { dragArrangement as DragArrangement } from './drag.arrangement';
+
+export function registerDragConcertmaster(
+  conductor: any,
+  deps: { store: any; dragArrangement: typeof DragArrangement }
+) {
+  const { store, dragArrangement } = deps;
+
+  conductor.on('Canvas.component-drag-symphony', 'start', ({ elementId }: any) => {
+    store.actions.select(elementId);
+    conductor.play('Overlay', 'hide-handles', { elementId });
+  });
+
+  conductor.on('Canvas.component-drag-symphony', 'update', ({ elementId, delta }: any) => {
+    const current = store.selectors.positionOf(elementId);
+    const next = dragArrangement.applyDelta(current, delta);
+    store.actions.move(elementId, next);
+    conductor.play('Overlay', 'transform', { elementId, dx: delta?.dx ?? 0, dy: delta?.dy ?? 0 });
+  });
+
+  conductor.on('Canvas.component-drag-symphony', 'end', ({ elementId }: any) => {
+    const pos = store.selectors.positionOf(elementId);
+    conductor.play('Overlay', 'commit-position', { elementId, position: pos });
+    conductor.play('Overlay', 'show-handles', { elementId });
+  });
+}
+

--- a/plugins/canvas-ui-plugin/features/overlay/overlay.arrangement.js
+++ b/plugins/canvas-ui-plugin/features/overlay/overlay.arrangement.js
@@ -1,0 +1,23 @@
+// Overlay Arrangement (Service): builds CSS rule strings; pure functions
+export const overlayArrangement = {
+  transformRule(elementId, dx = 0, dy = 0) {
+    const x = Math.round(dx) || 0;
+    const y = Math.round(dy) || 0;
+    return `.rx-overlay-${elementId}{transform:translate(${x}px,${y}px);}`;
+  },
+
+  hideRule(elementId) {
+    return `.rx-overlay-${elementId}{display:none;}`;
+  },
+
+  instanceRule(elementId, position = { x: 0, y: 0 }, size = {}) {
+    const x = typeof position.x === 'number' ? position.x : 0;
+    const y = typeof position.y === 'number' ? position.y : 0;
+    const w = size && typeof size.w === 'number' ? `${size.w}px` : size?.w;
+    const h = size && typeof size.h === 'number' ? `${size.h}px` : size?.h;
+    const widthLine = w != null ? `width:${w};` : '';
+    const heightLine = h != null ? `height:${h};` : '';
+    return `.rx-overlay-${elementId}{position:absolute;left:${x}px;top:${y}px;${widthLine}${heightLine}z-index:10;}`;
+  },
+};
+

--- a/plugins/canvas-ui-plugin/features/overlay/overlay.arrangement.ts
+++ b/plugins/canvas-ui-plugin/features/overlay/overlay.arrangement.ts
@@ -1,0 +1,27 @@
+// Overlay Arrangement (Service): builds CSS rule strings; pure functions
+export const overlayArrangement = {
+  transformRule(elementId: string, dx: number = 0, dy: number = 0): string {
+    const x = Math.round(dx) || 0;
+    const y = Math.round(dy) || 0;
+    return `.rx-overlay-${elementId}{transform:translate(${x}px,${y}px);}`;
+  },
+
+  hideRule(elementId: string): string {
+    return `.rx-overlay-${elementId}{display:none;}`;
+    },
+
+  instanceRule(
+    elementId: string,
+    position: { x?: number; y?: number } = { x: 0, y: 0 },
+    size: { w?: number | string; h?: number | string } = {}
+  ): string {
+    const x = typeof position.x === 'number' ? position.x : 0;
+    const y = typeof position.y === 'number' ? position.y : 0;
+    const w = typeof size.w === 'number' ? `${size.w}px` : size.w;
+    const h = typeof size.h === 'number' ? `${size.h}px` : size.h;
+    const widthLine = w != null ? `width:${w};` : '';
+    const heightLine = h != null ? `height:${h};` : '';
+    return `.rx-overlay-${elementId}{position:absolute;left:${x}px;top:${y}px;${widthLine}${heightLine}z-index:10;}`;
+  },
+};
+

--- a/plugins/canvas-ui-plugin/features/overlay/overlay.concertmaster.ts
+++ b/plugins/canvas-ui-plugin/features/overlay/overlay.concertmaster.ts
@@ -1,0 +1,49 @@
+// Overlay Concertmaster: listens to drag/selection cues and coordinates StageCrew
+import { overlayArrangement } from './overlay.arrangement';
+import { makeOverlayStageCrew } from './overlay.stage-crew';
+
+export function registerOverlayConcertmaster(
+  conductor: any,
+  deps: {
+    store: any,
+    cssAdapter: { upsertStyle: Function; removeStyle: Function };
+  }
+) {
+  const { store, cssAdapter } = deps;
+  const crew = makeOverlayStageCrew(cssAdapter, overlayArrangement);
+
+  // On drag start: hide handles
+  conductor.on('Canvas.component-drag-symphony', 'start', ({ elementId }: any) => {
+    crew.hide(elementId);
+  });
+
+  // On drag update: transform overlay (do not commit)
+  conductor.on(
+    'Canvas.component-drag-symphony',
+    'update',
+    ({ elementId, delta }: any) => {
+      const dx = delta?.dx ?? 0;
+      const dy = delta?.dy ?? 0;
+      crew.transform(elementId, dx, dy);
+    }
+  );
+
+  // On drag end: commit instance CSS to final position from Prompt Book and show handles
+  conductor.on('Canvas.component-drag-symphony', 'end', ({ elementId }: any) => {
+    const pos = store.selectors.positionOf(elementId);
+    crew.commitInstance(elementId, pos, {});
+    crew.show(elementId);
+  });
+
+  // On selection change: ensure overlay instance CSS exists and visible
+  conductor.on('Canvas.component-select-symphony', 'show', ({ elementId }: any) => {
+    const pos = store.selectors.positionOf(elementId);
+    crew.commitInstance(elementId, pos, {});
+    crew.show(elementId);
+  });
+
+  conductor.on('Canvas.component-select-symphony', 'hide', (_: any) => {
+    // No-op for now; could hide overlay entirely if desired
+  });
+}
+

--- a/plugins/canvas-ui-plugin/features/overlay/overlay.stage-crew.js
+++ b/plugins/canvas-ui-plugin/features/overlay/overlay.stage-crew.js
@@ -1,0 +1,21 @@
+// Overlay StageCrew (Adapter): applies arrangement CSS via a cssAdapter port
+export function makeOverlayStageCrew(cssAdapter, overlayArrangement) {
+  return {
+    transform(elementId, dx, dy) {
+      const css = overlayArrangement.transformRule(elementId, dx, dy);
+      cssAdapter.upsertStyle(`overlay-transform-${elementId}`, css);
+    },
+    hide(elementId) {
+      const css = overlayArrangement.hideRule(elementId);
+      cssAdapter.upsertStyle(`overlay-visibility-${elementId}`, css);
+    },
+    show(elementId) {
+      cssAdapter.removeStyle(`overlay-visibility-${elementId}`);
+    },
+    commitInstance(elementId, position, size) {
+      const css = overlayArrangement.instanceRule(elementId, position, size);
+      cssAdapter.upsertStyle(`overlay-instance-${elementId}`, css);
+    },
+  };
+}
+

--- a/plugins/canvas-ui-plugin/features/overlay/overlay.stage-crew.ts
+++ b/plugins/canvas-ui-plugin/features/overlay/overlay.stage-crew.ts
@@ -1,0 +1,21 @@
+// Overlay StageCrew (Adapter): applies arrangement CSS via a cssAdapter port
+export function makeOverlayStageCrew(cssAdapter: { upsertStyle: Function; removeStyle: Function }, overlayArrangement: any) {
+  return {
+    transform(elementId: string, dx: number, dy: number) {
+      const css = overlayArrangement.transformRule(elementId, dx, dy);
+      cssAdapter.upsertStyle(`overlay-transform-${elementId}`, css);
+    },
+    hide(elementId: string) {
+      const css = overlayArrangement.hideRule(elementId);
+      cssAdapter.upsertStyle(`overlay-visibility-${elementId}`, css);
+    },
+    show(elementId: string) {
+      cssAdapter.removeStyle(`overlay-visibility-${elementId}`);
+    },
+    commitInstance(elementId: string, position: { x: number; y: number }, size: { w?: number|string; h?: number|string }) {
+      const css = overlayArrangement.instanceRule(elementId, position, size);
+      cssAdapter.upsertStyle(`overlay-instance-${elementId}`, css);
+    },
+  };
+}
+

--- a/plugins/canvas-ui-plugin/features/selection/selection.concertmaster.ts
+++ b/plugins/canvas-ui-plugin/features/selection/selection.concertmaster.ts
@@ -1,0 +1,26 @@
+// Selection Concertmaster (Controller): orchestrates selection updates via Prompt Book
+export function registerSelectionConcertmaster(
+  conductor: any,
+  deps: { store: any }
+) {
+  const { store } = deps;
+
+  // Show selection -> set selectedId
+  conductor.on(
+    'Canvas.component-select-symphony',
+    'show',
+    ({ elementId }: any) => {
+      store.actions.select(elementId ?? null);
+    }
+  );
+
+  // Hide/clear selection -> set selectedId to null
+  conductor.on(
+    'Canvas.component-select-symphony',
+    'hide',
+    (_payload: any) => {
+      store.actions.select(null);
+    }
+  );
+}
+

--- a/plugins/canvas-ui-plugin/state/canvas.prompt-book.ts
+++ b/plugins/canvas-ui-plugin/state/canvas.prompt-book.ts
@@ -1,0 +1,122 @@
+// Canvas Prompt Book (Store): centralized, annotated state for the canvas
+// - Single source of truth for nodes and selection
+// - Concertmasters (controllers) are the only writers; Arrangements are pure; StageCrew never writes
+
+export type Vec2 = { x: number; y: number };
+export type CanvasNode = {
+  id?: string;
+  elementId?: string;
+  cssClass?: string;
+  position?: Vec2;
+  type?: string;
+  component?: any;
+  componentData?: any;
+};
+
+export type CanvasPromptBookState = {
+  nodes: CanvasNode[];
+  selectedId: string | null;
+};
+
+export type CanvasPromptBook = {
+  getState(): CanvasPromptBookState;
+  subscribe(listener: () => void): () => void;
+  actions: {
+    setNodes(nodes: CanvasNode[]): void;
+    select(id: string | null): void;
+    move(elementId: string, next: Vec2): void;
+  };
+  selectors: {
+    nodes(): CanvasNode[];
+    selectedId(): string | null;
+    nodeById(id: string): CanvasNode | null;
+    positionOf(id: string): Vec2;
+  };
+};
+
+function normalizeId(n?: CanvasNode | null): string | null {
+  if (!n) return null;
+  return (n.id || n.elementId || null) as string | null;
+}
+
+export function createCanvasPromptBook(
+  initial?: Partial<CanvasPromptBookState>
+): CanvasPromptBook {
+  let state: CanvasPromptBookState = {
+    nodes: Array.isArray(initial?.nodes) ? initial!.nodes!.slice() : [],
+    selectedId: initial?.selectedId ?? null,
+  };
+  const listeners = new Set<() => void>();
+
+  const notify = () => {
+    for (const l of Array.from(listeners)) {
+      try {
+        l();
+      } catch {}
+    }
+  };
+
+  const api: CanvasPromptBook = {
+    getState: () => state,
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    actions: {
+      setNodes(nodes: CanvasNode[]) {
+        state = { ...state, nodes: Array.isArray(nodes) ? nodes.slice() : [] };
+        notify();
+      },
+      select(id: string | null) {
+        state = { ...state, selectedId: id ?? null };
+        notify();
+      },
+      move(elementId: string, next: Vec2) {
+        const nodes = (state.nodes || []).map((n) => {
+          const nid = normalizeId(n);
+          if (nid === elementId) {
+            return { ...n, position: { x: next?.x ?? 0, y: next?.y ?? 0 } };
+          }
+          return n;
+        });
+        state = { ...state, nodes };
+        notify();
+      },
+    },
+    selectors: {
+      nodes() {
+        return state.nodes || [];
+      },
+      selectedId() {
+        return state.selectedId ?? null;
+      },
+      nodeById(id: string) {
+        const arr = state.nodes || [];
+        for (const n of arr) {
+          const nid = normalizeId(n);
+          if (nid === id) return n;
+        }
+        return null;
+      },
+      positionOf(id: string) {
+        const n = api.selectors.nodeById(id);
+        const p = n?.position;
+        return { x: p?.x ?? 0, y: p?.y ?? 0 };
+      },
+    },
+  };
+
+  return api;
+}
+
+// Default singleton Prompt Book for app runtime; tests can construct isolated instances
+export const canvasPromptBook = createCanvasPromptBook();
+
+// Safe window bridge for JS modules until migration completes
+try {
+  // @ts-ignore
+  if (typeof window !== "undefined") {
+    // @ts-ignore
+    (window as any).__rx_prompt_book__ = canvasPromptBook;
+  }
+} catch {}

--- a/plugins/manifest.json
+++ b/plugins/manifest.json
@@ -69,7 +69,7 @@
     {
       "name": "Canvas UI Plugin",
       "path": "canvas-ui-plugin/",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "description": "Canvas UI (center slot) - scaffold",
       "autoMount": true,
       "ui": { "slot": "center", "export": "CanvasPage" }

--- a/scripts/build-plugins.mjs
+++ b/scripts/build-plugins.mjs
@@ -10,6 +10,11 @@ async function ensureDir(p) {
   await fs.mkdir(p, { recursive: true });
 }
 
+async function cleanDir(p) {
+  // Remove directory recursively if it exists
+  await fs.rm(p, { recursive: true, force: true });
+}
+
 async function copyFileBinary(src, dest) {
   const buf = await fs.readFile(src);
   await ensureDir(path.dirname(dest));
@@ -33,6 +38,8 @@ async function copyDir(srcDir, destDir) {
 }
 
 async function main() {
+  // Clean dist to avoid stale artifacts
+  await cleanDir(distDir);
   await ensureDir(distDir);
   const entries = await fs.readdir(pluginsDir, { withFileTypes: true });
   for (const ent of entries) {

--- a/scripts/generate-manifest.mjs
+++ b/scripts/generate-manifest.mjs
@@ -44,6 +44,12 @@ async function collectPluginRelPaths(dir, relBase = "") {
 }
 
 async function main() {
+  // Read package version to sync manifest + plugin versions
+  const pkg = JSON.parse(
+    await fs.readFile(path.join(root, "package.json"), "utf8")
+  );
+  const version = pkg.version || "0.1.0";
+
   const relPaths = await collectPluginRelPaths(distDir, "");
   // De-duplicate
   const uniqueRelPaths = Array.from(new Set(relPaths));
@@ -58,13 +64,13 @@ async function main() {
     return {
       name: last.replace(/-/g, " "),
       path: relPath,
-      version: "0.1.0",
+      version,
       description: `${name} bundle`,
       autoMount: isHeaderUi ? false : true,
       ...(ui || {}),
     };
   });
-  const manifest = { version: "0.1.0", plugins };
+  const manifest = { version, plugins };
   await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
   console.log("wrote", manifestPath);
 }

--- a/tests/build/clean-build.test.js
+++ b/tests/build/clean-build.test.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const root = process.cwd();
+const distDir = path.join(root, 'dist');
+
+function run(cmd) {
+  execSync(cmd, { cwd: root, stdio: 'inherit' });
+}
+
+describe('build script', () => {
+  test('cleans dist before copying', () => {
+    // Arrange: create a stale file in dist
+    fs.mkdirSync(distDir, { recursive: true });
+    const staleFile = path.join(distDir, 'stale.txt');
+    fs.writeFileSync(staleFile, 'stale');
+    expect(fs.existsSync(staleFile)).toBe(true);
+
+    // Act: run the build script directly
+    run('node ./scripts/build-plugins.mjs');
+
+    // Assert: stale file should be gone; known plugin artifact should exist
+    expect(fs.existsSync(staleFile)).toBe(false);
+    expect(fs.existsSync(path.join(distDir, 'component-library-plugin', 'index.js'))).toBe(true);
+  });
+});
+

--- a/tests/manifest/version-sync.test.js
+++ b/tests/manifest/version-sync.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const root = process.cwd();
+
+function run(cmd) {
+  execSync(cmd, { cwd: root, stdio: 'inherit' });
+}
+
+describe('manifest generation', () => {
+  test('uses package.json version for manifest and plugin entries', () => {
+    // Act: regenerate manifest fresh
+    run('node ./scripts/generate-manifest.mjs');
+
+    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+    const manifest = JSON.parse(fs.readFileSync(path.join(root, 'dist', 'manifest.json'), 'utf8'));
+
+    expect(manifest.version).toBe(pkg.version);
+    for (const p of manifest.plugins) {
+      expect(p.version).toBe(pkg.version);
+    }
+  });
+});
+

--- a/tests/unit/bootstrap/concertmasters.bootstrap.rehearsal.test.ts
+++ b/tests/unit/bootstrap/concertmasters.bootstrap.rehearsal.test.ts
@@ -1,0 +1,76 @@
+import { registerCanvasConcertmasters } from "../../../plugins/canvas-ui-plugin/bootstrap/concertmasters.bootstrap";
+import { createCanvasPromptBook } from "../../../plugins/canvas-ui-plugin/state/canvas.prompt-book";
+
+function makeFakeConductor() {
+  const subs = new Map<string, Set<Function>>();
+  function emit(name: string, payload: any) {
+    const set = subs.get(name);
+    if (set)
+      set.forEach((fn) => {
+        try {
+          (fn as any)(payload);
+        } catch {}
+      });
+  }
+  const cx = {
+    play: jest.fn(),
+    on: (chan: string, act: string, cb: any) => {
+      const name = `${chan}:${act}`;
+      const set = subs.get(name) || new Set();
+      set.add(cb);
+      subs.set(name, set);
+      return () => {
+        const s = subs.get(name);
+        s?.delete(cb);
+      };
+    },
+    off: (chan: string, act: string, cb: any) => {
+      const name = `${chan}:${act}`;
+      const s = subs.get(name);
+      s?.delete(cb);
+    },
+    __emit: emit,
+  } as any;
+  return cx;
+}
+
+describe("Concertmasters Bootstrap Rehearsal", () => {
+  it("wires drag concertmaster: start, update, end update Prompt Book and play overlay", () => {
+    const conductor = makeFakeConductor();
+    const store = createCanvasPromptBook({
+      nodes: [{ id: "a", position: { x: 0, y: 0 } }],
+    });
+    registerCanvasConcertmasters(conductor, { store });
+
+    // start selects and hides handles
+    conductor.__emit("Canvas.component-drag-symphony:start", {
+      elementId: "a",
+    });
+    expect(store.selectors.selectedId()).toBe("a");
+    expect(conductor.play).toHaveBeenCalledWith("Overlay", "hide-handles", {
+      elementId: "a",
+    });
+
+    // update moves and transforms overlay
+    conductor.__emit("Canvas.component-drag-symphony:update", {
+      elementId: "a",
+      delta: { dx: 3, dy: -2 },
+    });
+    expect(store.selectors.positionOf("a")).toEqual({ x: 3, y: -2 });
+    expect(conductor.play).toHaveBeenCalledWith("Overlay", "transform", {
+      elementId: "a",
+      dx: 3,
+      dy: -2,
+    });
+
+    // end commits position and shows handles
+    conductor.__emit("Canvas.component-drag-symphony:end", { elementId: "a" });
+    expect(conductor.play).toHaveBeenCalledWith("Overlay", "commit-position", {
+      elementId: "a",
+      position: { x: 3, y: -2 },
+    });
+    expect(conductor.play).toHaveBeenCalledWith("Overlay", "show-handles", {
+      elementId: "a",
+    });
+  });
+});

--- a/tests/unit/core/binder/CapabilityBinder.rehearsal.test.js
+++ b/tests/unit/core/binder/CapabilityBinder.rehearsal.test.js
@@ -1,0 +1,56 @@
+const path = require("path");
+
+describe("CapabilityBinder", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("resolves explicit behavior binding from component JSON", () => {
+    const binder = require("../../../../core/binder/CapabilityBinder.js");
+    const node = {
+      id: "n1",
+      component: {
+        metadata: { type: "button", name: "Button" },
+        behaviors: {
+          drag: { plugin: "Canvas.component-drag-symphony" }
+        }
+      }
+    };
+
+    const id = binder.resolvePluginId(node, "drag");
+    expect(id).toBe("Canvas.component-drag-symphony");
+  });
+
+  test("falls back to type default from registry when behavior missing", () => {
+    const binder = require("../../../../core/binder/CapabilityBinder.js");
+    const node = {
+      id: "n2",
+      component: { metadata: { type: "line", name: "Line" } }
+    };
+    const id = binder.resolvePluginId(node, "drag");
+    // For now defaults map line.drag to existing drag symphony id
+    expect(id).toBe("Canvas.component-drag-symphony");
+  });
+
+  test("falls back to wildcard default and play() uses id for both args", async () => {
+    const binder = require("../../../../core/binder/CapabilityBinder.js");
+    const node = {
+      id: "n3",
+      component: { metadata: { type: "unknown", name: "Unknown" } }
+    };
+
+    // wildcard default for 'select' should exist
+    const id = binder.resolvePluginId(node, "select");
+    expect(id).toBe("Canvas.component-select-symphony");
+
+    // play() calls conductor with (id,id,payload+config)
+    const calls = [];
+    const conductor = { play: (channel, seqId, payload) => { calls.push({ channel, seqId, payload }); return Promise.resolve(); } };
+    await binder.play(conductor, node, "select", { foo: 1 });
+    expect(calls.length).toBe(1);
+    expect(calls[0].channel).toBe("Canvas.component-select-symphony");
+    expect(calls[0].seqId).toBe("Canvas.component-select-symphony");
+    expect(calls[0].payload.foo).toBe(1);
+  });
+});
+

--- a/tests/unit/features/drag/drag.rehearsal.test.ts
+++ b/tests/unit/features/drag/drag.rehearsal.test.ts
@@ -1,0 +1,43 @@
+// Drag Rehearsal: arrangement math and concertmaster orchestration
+import { dragArrangement } from '../../../../plugins/canvas-ui-plugin/features/drag/drag.arrangement';
+import { registerDragConcertmaster } from '../../../../plugins/canvas-ui-plugin/features/drag/drag.concertmaster';
+
+describe('Drag Rehearsal', () => {
+  it('arrangement.applyDelta moves by dx/dy', () => {
+    expect(dragArrangement.applyDelta({ x: 10, y: 5 }, { dx: 3, dy: -2 })).toEqual({ x: 13, y: 3 });
+    expect(dragArrangement.applyDelta({ x: 0, y: 0 }, { dx: -1, dy: 2 })).toEqual({ x: -1, y: 2 });
+  });
+
+  it('concertmaster reacts to start/update/end with expected plays and store updates', () => {
+    const plays: any[] = [];
+    const onHandlers: Record<string, Function> = {};
+    const conductor = {
+      on: (channel: string, action: string, cb: Function) => {
+        onHandlers[`${channel}:${action}`] = cb;
+      },
+      play: (channel: string, action: string, payload: any) => {
+        plays.push({ channel, action, payload });
+      },
+    } as any;
+
+    const store = {
+      selectors: { positionOf: (_id: string) => ({ x: 10, y: 5 }) },
+      actions: { select: jest.fn(), move: jest.fn() },
+    };
+
+    registerDragConcertmaster(conductor, { store, dragArrangement });
+
+    onHandlers['Canvas.component-drag-symphony:start']({ elementId: 'A' });
+    expect(store.actions.select).toHaveBeenCalledWith('A');
+    expect(plays).toContainEqual({ channel: 'Overlay', action: 'hide-handles', payload: { elementId: 'A' } });
+
+    onHandlers['Canvas.component-drag-symphony:update']({ elementId: 'A', delta: { dx: 3, dy: 7 } });
+    expect(store.actions.move).toHaveBeenCalledWith('A', { x: 13, y: 12 });
+    expect(plays).toContainEqual({ channel: 'Overlay', action: 'transform', payload: { elementId: 'A', dx: 3, dy: 7 } });
+
+    onHandlers['Canvas.component-drag-symphony:end']({ elementId: 'A' });
+    expect(plays).toContainEqual({ channel: 'Overlay', action: 'commit-position', payload: { elementId: 'A', position: { x: 10, y: 5 } } });
+    expect(plays).toContainEqual({ channel: 'Overlay', action: 'show-handles', payload: { elementId: 'A' } });
+  });
+});
+

--- a/tests/unit/features/overlay/overlay.rehearsal.test.ts
+++ b/tests/unit/features/overlay/overlay.rehearsal.test.ts
@@ -1,0 +1,72 @@
+// Overlay Arrangement to be implemented under features/overlay
+// In rehearsals, we test the pure rules first
+import { overlayArrangement } from "../../../../plugins/canvas-ui-plugin/features/overlay/overlay.arrangement";
+import { makeOverlayStageCrew } from "../../../../plugins/canvas-ui-plugin/features/overlay/overlay.stage-crew";
+
+// A minimal cssAdapter mock to verify StageCrew behavior
+const cssAdapter = {
+  upsertStyle: jest.fn(),
+  removeStyle: jest.fn(),
+};
+
+describe("Overlay Rehearsal", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    cssAdapter.upsertStyle.mockClear();
+    cssAdapter.removeStyle.mockClear();
+  });
+
+  it("arrangement builds transform rule", () => {
+    const css = overlayArrangement.transformRule("abc", 5.2, -3.7);
+    expect(css).toContain(".rx-overlay-abc");
+    expect(css).toContain("transform:translate(5px,-4px)");
+  });
+
+  it("arrangement builds hide/show rules", () => {
+    const hide = overlayArrangement.hideRule("xyz");
+    expect(hide).toContain(".rx-overlay-xyz");
+    expect(hide).toContain("display:none");
+
+    // show is implemented by removing the style via StageCrew
+  });
+
+  it("arrangement builds instance rule with position and size", () => {
+    const css = overlayArrangement.instanceRule(
+      "n1",
+      { x: 10, y: 20 },
+      { w: 100, h: 80 }
+    );
+    expect(css).toContain(".rx-overlay-n1");
+    expect(css).toContain("left:10px");
+    expect(css).toContain("top:20px");
+    expect(css).toContain("width:100px");
+    expect(css).toContain("height:80px");
+  });
+
+  it("stage crew can transform/hide/show/commit via cssAdapter with arrangement rules", () => {
+    const crew = makeOverlayStageCrew(cssAdapter, overlayArrangement);
+
+    crew.transform("el1", 3, 7);
+    expect(cssAdapter.upsertStyle).toHaveBeenCalledWith(
+      "overlay-transform-el1",
+      expect.stringContaining("transform:translate(3px,7px)")
+    );
+
+    crew.hide("el1");
+    expect(cssAdapter.upsertStyle).toHaveBeenCalledWith(
+      "overlay-visibility-el1",
+      expect.stringContaining("display:none")
+    );
+
+    crew.show("el1");
+    expect(cssAdapter.removeStyle).toHaveBeenCalledWith(
+      "overlay-visibility-el1"
+    );
+
+    crew.commitInstance("el1", { x: 5, y: 6 }, { w: 10, h: 11 });
+    expect(cssAdapter.upsertStyle).toHaveBeenCalledWith(
+      "overlay-instance-el1",
+      expect.stringContaining("left:5px")
+    );
+  });
+});

--- a/tests/unit/features/selection/selection.concertmaster.rehearsal.test.ts
+++ b/tests/unit/features/selection/selection.concertmaster.rehearsal.test.ts
@@ -1,0 +1,44 @@
+import { registerSelectionConcertmaster } from "../../../../plugins/canvas-ui-plugin/features/selection/selection.concertmaster";
+import { createCanvasPromptBook } from "../../../../plugins/canvas-ui-plugin/state/canvas.prompt-book";
+
+describe("Selection Concertmaster Rehearsal", () => {
+  function makeFakeConductor() {
+    const subs = new Map<string, Set<Function>>();
+    function emit(name: string, payload: any) {
+      const set = subs.get(name);
+      set?.forEach((fn) => {
+        try {
+          (fn as any)(payload);
+        } catch {}
+      });
+    }
+    const cx = {
+      on: (chan: string, act: string, cb: any) => {
+        const name = `${chan}:${act}`;
+        const set = subs.get(name) || new Set();
+        set.add(cb);
+        subs.set(name, set);
+        return () => {
+          const s = subs.get(name);
+          s?.delete(cb);
+        };
+      },
+      __emit: emit,
+    } as any;
+    return cx;
+  }
+
+  it("sets selectedId on show and clears on hide", () => {
+    const store = createCanvasPromptBook();
+    const conductor = makeFakeConductor();
+    registerSelectionConcertmaster(conductor, { store });
+
+    conductor.__emit("Canvas.component-select-symphony:show", {
+      elementId: "x",
+    });
+    expect(store.selectors.selectedId()).toBe("x");
+
+    conductor.__emit("Canvas.component-select-symphony:hide", {});
+    expect(store.selectors.selectedId()).toBeNull();
+  });
+});

--- a/tests/unit/flows/drag-after-drop-baseline.test.js
+++ b/tests/unit/flows/drag-after-drop-baseline.test.js
@@ -1,0 +1,85 @@
+const { loadRenderXPlugin } = require("../../utils/renderx-plugin-loader");
+const { TestEnvironment } = require("../../utils/test-helpers");
+
+// This test guards against stale baselines after a dynamic node is added (drop -> then drag)
+// Red: should fail before CanvasPage syncs Prompt Book on prop changes
+
+describe("Canvas UI: baseline after drop persists for subsequent drag (dynamic node add)", () => {
+  function makeButton() {
+    return {
+      id: "rx-btn-1",
+      cssClass: "rx-btn-1",
+      type: "button",
+      position: { x: 400, y: 300 },
+      component: {
+        metadata: { name: "Button", type: "button" },
+        ui: { template: '<button class="rx-button">OK</button>', styles: { css: ".rx-button{color:#000}" } },
+        integration: { canvasIntegration: { defaultWidth: 100, defaultHeight: 30 } },
+      },
+    };
+  }
+  function makeInput(pos) {
+    return {
+      id: "rx-input-1",
+      cssClass: "rx-input-1",
+      type: "input",
+      position: pos || { x: 200, y: 200 },
+      component: {
+        metadata: { name: "Input", type: "input" },
+        ui: { template: '<input class="rx-input" />', styles: { css: ".rx-input{color:#000}" } },
+        integration: { canvasIntegration: { defaultWidth: 160, defaultHeight: 28 } },
+      },
+    };
+  }
+
+  test("after drop (node add), dragging the new node keeps baseline and does not snap back", async () => {
+    // Arrange
+    while (document.head.firstChild) document.head.removeChild(document.head.firstChild);
+    global.window = global.window || {};
+
+    const eventBus = TestEnvironment.createEventBus();
+    const conductor = TestEnvironment.createMusicalConductor(eventBus);
+    window.renderxCommunicationSystem = { conductor };
+
+    const { registerCanvasConcertmasters } = require("../../../plugins/canvas-ui-plugin/bootstrap/concertmasters.bootstrap");
+    const cx = {
+      play: conductor.play.bind(conductor),
+      on: (chan, act, cb) => eventBus.subscribe(`${chan}:${act}`, cb),
+      off: (chan, act, cb) => eventBus.unsubscribe(`${chan}:${act}`, cb),
+    };
+    registerCanvasConcertmasters(cx);
+
+    // Minimal React stub
+    window.React = {
+      createElement: (type, props, ...children) => ({ type, props, children }),
+      useEffect: (fn) => fn(),
+      useState: (init) => [init, () => {}],
+      cloneElement: (el, p) => ({ ...el, props: { ...(el.props || {}), ...(p || {}) } }),
+    };
+
+    const plugin = loadRenderXPlugin("RenderX/public/plugins/canvas-ui-plugin/index.js");
+
+    // Initial render with only button
+    const btn = makeButton();
+    plugin.CanvasPage({ nodes: [btn], selectedId: btn.id });
+
+    // Simulate drop of input by re-rendering with new nodes including input
+    const input = makeInput({ x: 500, y: 320 }); // dropped near the button
+    plugin.CanvasPage({ nodes: [btn, input], selectedId: input.id });
+
+    // Act: get drag handlers for the input and drag by small delta
+    const el = plugin.renderCanvasNode(input);
+    const domEl = document.createElement("div");
+
+    el.props.onPointerDown({ currentTarget: domEl, clientX: 0, clientY: 0, pointerId: 1, target: { setPointerCapture() {} }, stopPropagation() {} });
+    el.props.onPointerMove({ currentTarget: domEl, clientX: 10, clientY: 5 });
+    await new Promise((r) => setTimeout(r, 25));
+    el.props.onPointerUp({ currentTarget: domEl, clientX: 10, clientY: 5, pointerId: 1, target: { releasePointerCapture() {} } });
+
+    // Assert: per-instance CSS should reflect baseline (500,320) + delta (10,5) = (510,325)
+    const tag = document.getElementById(`component-instance-css-${input.id}`);
+    const css = (tag?.textContent || "").replace(/\s+/g, "");
+    expect(css).toContain(`.${input.cssClass}{position:absolute;left:510px;top:325px;`.replace(/\s+/g, ""));
+  });
+});
+

--- a/tests/unit/flows/overlay-reposition-and-baseline-persist.test.js
+++ b/tests/unit/flows/overlay-reposition-and-baseline-persist.test.js
@@ -10,31 +10,55 @@ describe("Canvas UI: overlay repositions on drop and baseline persists across dr
       position: { x: 10, y: 20 },
       component: {
         metadata: { name: "Button", type: "button" },
-        ui: { template: '<button class="rx-button">OK</button>', styles: { css: '.rx-button{color:#000}' } },
-        integration: { canvasIntegration: { defaultWidth: 100, defaultHeight: 30 } },
+        ui: {
+          template: '<button class="rx-button">OK</button>',
+          styles: { css: ".rx-button{color:#000}" },
+        },
+        integration: {
+          canvasIntegration: { defaultWidth: 100, defaultHeight: 30 },
+        },
       },
     };
   }
 
   test("overlay base CSS updates to committed pos on first drop; second drag uses updated baseline", async () => {
     // Reset head and set up env
-    while (document.head.firstChild) document.head.removeChild(document.head.firstChild);
+    while (document.head.firstChild)
+      document.head.removeChild(document.head.firstChild);
     global.window = global.window || {};
 
     const eventBus = TestEnvironment.createEventBus();
     const conductor = TestEnvironment.createMusicalConductor(eventBus);
     window.renderxCommunicationSystem = { conductor };
+    const {
+      registerCanvasConcertmasters,
+    } = require("../../../plugins/canvas-ui-plugin/bootstrap/concertmasters.bootstrap");
+    const cx = {
+      play: conductor.play.bind(conductor),
+      on: (chan, act, cb) => eventBus.subscribe(`${chan}:${act}`, cb),
+      off: (chan, act, cb) => eventBus.unsubscribe(`${chan}:${act}`, cb),
+    };
+    registerCanvasConcertmasters(cx);
 
     // React stub
     const created = [];
     window.React = {
-      createElement: (type, props, ...children) => { const el = { type, props, children }; created.push(el); return el; },
+      createElement: (type, props, ...children) => {
+        const el = { type, props, children };
+        created.push(el);
+        return el;
+      },
       useEffect: (fn) => fn(),
       useState: (init) => [init, () => {}],
-      cloneElement: (el, p) => ({ ...el, props: { ...(el.props||{}), ...(p||{}) } }),
+      cloneElement: (el, p) => ({
+        ...el,
+        props: { ...(el.props || {}), ...(p || {}) },
+      }),
     };
 
-    const plugin = loadRenderXPlugin("RenderX/public/plugins/canvas-ui-plugin/index.js");
+    const plugin = loadRenderXPlugin(
+      "RenderX/public/plugins/canvas-ui-plugin/index.js"
+    );
 
     const node = makeNode();
     // Render page with selection so overlay exists
@@ -43,39 +67,84 @@ describe("Canvas UI: overlay repositions on drop and baseline persists across dr
 
     // Render element to get handlers
     const el = plugin.renderCanvasNode(node);
-    const domEl = document.createElement('div');
+    const domEl = document.createElement("div");
 
     // First drag: move by (dx1, dy1) = (15, 12)
-    el.props.onPointerDown({ currentTarget: domEl, clientX: 0, clientY: 0, pointerId: 1, target: { setPointerCapture(){} }, stopPropagation(){} });
+    el.props.onPointerDown({
+      currentTarget: domEl,
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+      target: { setPointerCapture() {} },
+      stopPropagation() {},
+    });
     el.props.onPointerMove({ currentTarget: domEl, clientX: 15, clientY: 12 });
     // Allow rAF
-    await new Promise(r => setTimeout(r, 25));
-    el.props.onPointerUp({ currentTarget: domEl, clientX: 15, clientY: 12, pointerId: 1, target: { releasePointerCapture(){} } });
+    await new Promise((r) => setTimeout(r, 25));
+    el.props.onPointerUp({
+      currentTarget: domEl,
+      clientX: 15,
+      clientY: 12,
+      pointerId: 1,
+      target: { releasePointerCapture() {} },
+    });
 
     // After first drop: instance CSS updated to (25,32)
     const inst1 = document.getElementById(`component-instance-css-${node.id}`);
-    const c1 = (inst1?.textContent||'').replace(/\s+/g, '');
-    expect(c1).toContain(`.${node.cssClass}{position:absolute;left:25px;top:32px;`.replace(/\s+/g, ''));
+    const c1 = (inst1?.textContent || "").replace(/\s+/g, "");
+    expect(c1).toContain(
+      `.${node.cssClass}{position:absolute;left:25px;top:32px;`.replace(
+        /\s+/g,
+        ""
+      )
+    );
 
     // Overlay base CSS should now reflect (25,32)
-    const ov1 = document.getElementById(`overlay-css-${node.id}`);
-    const o1 = (ov1?.textContent||'').replace(/\s+/g, '');
-    expect(o1).toContain(`.rx-overlay-${node.id}{position:absolute;left:25px;top:32px;`.replace(/\s+/g, ''));
+    const ov1 = document.getElementById(`overlay-instance-${node.id}`);
+    const o1 = (ov1?.textContent || "").replace(/\s+/g, "");
+    expect(o1).toContain(
+      `.rx-overlay-${node.id}{position:absolute;left:25px;top:32px;`.replace(
+        /\s+/g,
+        ""
+      )
+    );
 
     // Second drag: move by (dx2, dy2) = (5, 7)
-    el.props.onPointerDown({ currentTarget: domEl, clientX: 0, clientY: 0, pointerId: 2, target: { setPointerCapture(){} }, stopPropagation(){} });
+    el.props.onPointerDown({
+      currentTarget: domEl,
+      clientX: 0,
+      clientY: 0,
+      pointerId: 2,
+      target: { setPointerCapture() {} },
+      stopPropagation() {},
+    });
     el.props.onPointerMove({ currentTarget: domEl, clientX: 5, clientY: 7 });
-    await new Promise(r => setTimeout(r, 25));
-    el.props.onPointerUp({ currentTarget: domEl, clientX: 5, clientY: 7, pointerId: 2, target: { releasePointerCapture(){} } });
+    await new Promise((r) => setTimeout(r, 25));
+    el.props.onPointerUp({
+      currentTarget: domEl,
+      clientX: 5,
+      clientY: 7,
+      pointerId: 2,
+      target: { releasePointerCapture() {} },
+    });
 
     // Final expected position = (25+5, 32+7) = (30, 39)
     const inst2 = document.getElementById(`component-instance-css-${node.id}`);
-    const c2 = (inst2?.textContent||'').replace(/\s+/g, '');
-    expect(c2).toContain(`.${node.cssClass}{position:absolute;left:30px;top:39px;`.replace(/\s+/g, ''));
+    const c2 = (inst2?.textContent || "").replace(/\s+/g, "");
+    expect(c2).toContain(
+      `.${node.cssClass}{position:absolute;left:30px;top:39px;`.replace(
+        /\s+/g,
+        ""
+      )
+    );
 
-    const ov2 = document.getElementById(`overlay-css-${node.id}`);
-    const o2 = (ov2?.textContent||'').replace(/\s+/g, '');
-    expect(o2).toContain(`.rx-overlay-${node.id}{position:absolute;left:30px;top:39px;`.replace(/\s+/g, ''));
+    const ov2 = document.getElementById(`overlay-instance-${node.id}`);
+    const o2 = (ov2?.textContent || "").replace(/\s+/g, "");
+    expect(o2).toContain(
+      `.rx-overlay-${node.id}{position:absolute;left:30px;top:39px;`.replace(
+        /\s+/g,
+        ""
+      )
+    );
   });
 });
-

--- a/tests/unit/plugins/canvas-ui-plugin-drag-perf.test.js
+++ b/tests/unit/plugins/canvas-ui-plugin-drag-perf.test.js
@@ -146,7 +146,12 @@ describe("Canvas UI drag performance contract", () => {
   });
 
   test("conductor.play counts: start=1, move ≤ frames, end=1", async () => {
-    const node = { id: "id-3", position: { x: 0, y: 0 }, cssClass: "id-3" };
+    const node = {
+      id: "id-3",
+      position: { x: 0, y: 0 },
+      cssClass: "id-3",
+      component: { metadata: { type: "button", name: "Button" } },
+    };
     handlers = mod.attachDragHandlers(node);
 
     const calls = [];
@@ -200,4 +205,126 @@ describe("Canvas UI drag performance contract", () => {
     expect(moveCount).toBeLessThanOrEqual(2); // one per rAF frame
     expect(endCount).toBe(1);
   });
+});
+
+describe("Canvas UI drag performance contract (id shape)", () => {
+  test("conductor.play only uses sequence id (no phase id)", async () => {
+    // Local setup to avoid relying on outer describe
+    const localBus = TestEnvironment.createEventBus();
+    const localConductor = TestEnvironment.createMusicalConductor(localBus);
+    global.window = global.window || {};
+    global.document = global.document || window.document;
+    window.renderxCommunicationSystem = { conductor: localConductor };
+
+    const localEl = document.createElement("div");
+    document.body.appendChild(localEl);
+    const callbacks = [];
+    window.__testRafCallbacks = callbacks;
+    window.requestAnimationFrame = (cb) => {
+      callbacks.push(cb);
+      return callbacks.length;
+    };
+
+    const localMod = loadRenderXPlugin(dragHandlersModulePath);
+    const node = { id: "id-4", position: { x: 0, y: 0 }, cssClass: "id-4" };
+    const localHandlers = localMod.attachDragHandlers(node);
+
+    const calls = [];
+    jest
+      .spyOn(localConductor, "play")
+      .mockImplementation((channel, id, payload) => {
+        let mod;
+
+        calls.push({ channel, id, payload });
+        return Promise.resolve();
+      });
+
+    // Start drag
+    localHandlers.onPointerDown(
+      makeEvent("pointerdown", {
+        currentTarget: localEl,
+        clientX: 0,
+        clientY: 0,
+      })
+    );
+    // Move a bit and flush a frame
+    localHandlers.onPointerMove(
+      makeEvent("pointermove", {
+        currentTarget: localEl,
+        clientX: 10,
+        clientY: 5,
+      })
+    );
+    // Local flush (avoid depending on outer describe helper)
+    const localFlush = (times = 1) => {
+      for (let i = 0; i < times; i++) {
+        const cbs = window.__testRafCallbacks.splice(0);
+        cbs.forEach((cb) => cb(performance.now()));
+      }
+    };
+    localFlush(1);
+    // End
+    localHandlers.onPointerUp(
+      makeEvent("pointerup", {
+        currentTarget: localEl,
+        clientX: 10,
+        clientY: 5,
+      })
+    );
+
+    // Allow async binder fallback to resolve
+    await Promise.resolve();
+    // Assert: every call uses the sequence id as id (not 'start'/'update'/'end')
+    expect(calls.length).toBeGreaterThanOrEqual(2); // start + end at minimum
+    for (const c of calls) {
+      expect(c.id).toBe("Canvas.component-drag-symphony");
+    }
+  });
+});
+
+test("drag uses CapabilityBinder-resolved plugin id (default)", async () => {
+  // Local setup
+  const localBus = TestEnvironment.createEventBus();
+  const localConductor = TestEnvironment.createMusicalConductor(localBus);
+  global.window = global.window || {};
+  global.document = global.document || window.document;
+  window.renderxCommunicationSystem = { conductor: localConductor };
+
+  const localEl = document.createElement("div");
+  document.body.appendChild(localEl);
+
+  const localMod = loadRenderXPlugin(dragHandlersModulePath);
+  const node = {
+    id: "id-binder-1",
+    position: { x: 0, y: 0 },
+    cssClass: "id-binder-1",
+    component: { metadata: { type: "button", name: "Button" } },
+  };
+  const localHandlers = localMod.attachDragHandlers(node);
+
+  const calls = [];
+  jest
+    .spyOn(localConductor, "play")
+    .mockImplementation((channel, id, payload) => {
+      calls.push({ channel, id, payload });
+      return Promise.resolve();
+    });
+
+  localHandlers.onPointerDown(
+    makeEvent("pointerdown", { currentTarget: localEl, clientX: 0, clientY: 0 })
+  );
+  localHandlers.onPointerMove(
+    makeEvent("pointermove", { currentTarget: localEl, clientX: 5, clientY: 5 })
+  );
+  // Flush one frame
+  const cbs = window.__testRafCallbacks.splice(0);
+  cbs.forEach((cb) => cb(performance.now()));
+
+  localHandlers.onPointerUp(
+    makeEvent("pointerup", { currentTarget: localEl, clientX: 5, clientY: 5 })
+  );
+
+  // Expect at least start and end and that id equals defaults for button.drag
+  const ids = calls.map((c) => c.id);
+  expect(ids.every((x) => x === "Canvas.component-drag-symphony")).toBe(true);
 });

--- a/tests/unit/plugins/canvas-ui-plugin-drag-perf.test.js
+++ b/tests/unit/plugins/canvas-ui-plugin-drag-perf.test.js
@@ -107,9 +107,11 @@ describe("Canvas UI drag performance contract", () => {
   });
 
   test("does not update per-instance CSS or setNodes during drag; commits once on pointerup", async () => {
-    // Expose a commit callback to simulate CanvasPage state commit
-    window.__rx_canvas_ui__ = window.__rx_canvas_ui__ || {};
-    window.__rx_canvas_ui__.commitNodePosition = jest.fn();
+    // Provide Prompt Book shim to capture commits
+    window.__rx_prompt_book__ = {
+      actions: { move: jest.fn() },
+      selectors: { positionOf: () => ({ x: 0, y: 0 }) },
+    };
 
     const node = { id: "id-2", position: { x: 0, y: 0 }, cssClass: "id-2" };
     handlers = mod.attachDragHandlers(node);
@@ -140,7 +142,7 @@ describe("Canvas UI drag performance contract", () => {
 
     const tag = document.getElementById(tagId);
     expect(tag).not.toBeNull();
-    expect(window.__rx_canvas_ui__.commitNodePosition).toHaveBeenCalledTimes(1);
+    expect(window.__rx_prompt_book__.actions.move).toHaveBeenCalledTimes(1);
   });
 
   test("conductor.play counts: start=1, move ≤ frames, end=1", async () => {

--- a/tests/unit/plugins/canvas-ui-plugin-overlay-visibility-and-cursor.test.js
+++ b/tests/unit/plugins/canvas-ui-plugin-overlay-visibility-and-cursor.test.js
@@ -12,6 +12,15 @@ describe("Canvas UI overlay visibility during drag and cursor policy", () => {
     const conductor = TestEnvironment.createMusicalConductor(eventBus);
     global.window = global.window || {};
     window.renderxCommunicationSystem = { conductor };
+    const {
+      registerCanvasConcertmasters,
+    } = require("../../../plugins/canvas-ui-plugin/bootstrap/concertmasters.bootstrap");
+    const cx = {
+      play: conductor.play.bind(conductor),
+      on: (chan, act, cb) => eventBus.subscribe(`${chan}:${act}`, cb),
+      off: (chan, act, cb) => eventBus.unsubscribe(`${chan}:${act}`, cb),
+    };
+    registerCanvasConcertmasters(cx);
 
     // React stub collects created elements
     const created = [];

--- a/tests/unit/state/canvas.prompt-book.rehearsal.test.ts
+++ b/tests/unit/state/canvas.prompt-book.rehearsal.test.ts
@@ -1,0 +1,44 @@
+import { createCanvasPromptBook } from '../../../plugins/canvas-ui-plugin/state/canvas.prompt-book';
+
+describe('Canvas Prompt Book Rehearsal', () => {
+  it('initializes with nodes and selectedId and exposes selectors', () => {
+    const pb = createCanvasPromptBook({ nodes: [{ id: 'a', position: { x: 1, y: 2 } }], selectedId: 'a' });
+    expect(pb.selectors.nodes()).toHaveLength(1);
+    expect(pb.selectors.selectedId()).toBe('a');
+    expect(pb.selectors.positionOf('a')).toEqual({ x: 1, y: 2 });
+    expect(pb.selectors.nodeById('a')?.id).toBe('a');
+  });
+
+  it('actions.select updates selectedId', () => {
+    const pb = createCanvasPromptBook();
+    pb.actions.select('x');
+    expect(pb.selectors.selectedId()).toBe('x');
+    pb.actions.select(null as any);
+    expect(pb.selectors.selectedId()).toBeNull();
+  });
+
+  it('actions.setNodes and actions.move update node positions immutably', () => {
+    const pb = createCanvasPromptBook({ nodes: [{ id: 'a', position: { x: 0, y: 0 } }, { elementId: 'b' }] });
+    pb.actions.move('a', { x: 5, y: 6 });
+    expect(pb.selectors.positionOf('a')).toEqual({ x: 5, y: 6 });
+
+    pb.actions.setNodes([{ id: 'a', position: { x: 10, y: 10 } }]);
+    expect(pb.selectors.nodes()).toHaveLength(1);
+    expect(pb.selectors.positionOf('a')).toEqual({ x: 10, y: 10 });
+  });
+
+  it('subscribe notifies on changes and allows unsubscribe', () => {
+    const pb = createCanvasPromptBook();
+    const calls: number[] = [];
+    const unsub = pb.subscribe(() => calls.push(Date.now()));
+    pb.actions.select('a');
+    pb.actions.setNodes([{ id: 'a' } as any]);
+    pb.actions.move('a', { x: 1, y: 2 });
+    unsub();
+    pb.actions.select(null);
+    const notified = calls.length;
+    pb.actions.select('b');
+    expect(calls.length).toBe(notified);
+  });
+});
+


### PR DESCRIPTION
This PR introduces JSON-driven capability bindings and wires Canvas drag through the new binder, aligned with ADR-0002.

What’s in this PR
- core/binder/CapabilityBinder.js: resolves (node, capability) → pluginId from component JSON → type defaults → wildcard; play() calls conductor.play(id, id, payload)
- core/registry/defaults.json: initial type defaults (button/input/line)
- plugins/canvas-ui-plugin/handlers/drag.js: uses binder.play for start/update/end with legacy fallback to Canvas.component-drag-symphony
- tests/unit/core/binder/CapabilityBinder.rehearsal.test.js: binder resolution tests
- tests/unit/plugins/canvas-ui-plugin-drag-perf.test.js: add binder id assertion and keep existing perf/id-shape tests green
- tests/unit/flows/drag-after-drop-baseline.test.js: regression guard for baseline after drop
- tests/utils/renderx-plugin-loader.ts: enhanced to support CommonJS globals and JSON requires in test-evaluated modules
- docs/adr/ADR-0002-json-driven-capability-bindings.md: expanded with profiles/solutions, BDD test layering, telemetry adapter, migration notes
- docs/adr/ADR-0001-orchestral-architecture.md: marked as superseded by ADR-0002

Why
- Aligns with architecture vision: component JSON drives capability→plugin linkages; plugins stay component-agnostic; Conductor + Prompt Book are the stable surfaces.
- Establishes a scalable path for profiles/solutions and telemetry.

Next steps (separate PRs)
- Add component JSONs per library component and wire overlay/selection via binder
- Introduce line-specific resize plugin and bind it in line.component.json
- Add schema validation for component JSON and registry in CI

Refs: #14, ADR-0002

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author