### PR TITLE
chore(#21): add dev server and Playwright e2e to verify StageCrew commits; save logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,9 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 /.vs
 /.logs
+
+# Allow committed docs logs
+!docs/logs/
+!docs/logs/*.md
+
 /.*

--- a/docs/logs/console.sample.md
+++ b/docs/logs/console.sample.md
@@ -1,0 +1,23 @@
+# Playwright Console Log (StageCrew Drag Session)
+
+- Timestamp: 2025-08-18 00:00:00 UTC
+- Source: tests/e2e/drag-stagecrew.html harness
+
+[console] LOG: [StageCrew upsertStyleTag] overlay-css-global .rx-resize-overlay{position:absolute;pointer-events:none;}
+[console] LOG: [StageCrew upsertStyleTag] overlay-css-rx-e2e-button .rx-overlay-rx-e2e-button{position:absolute;left:10px;top:20px;width:100px;height:30px;z-index:10;}
+[console] LOG: [StageCrew beginBeat] drag:start:rx-e2e-button {"handlerName":"dragStart","plugin":"canvas-ui-plugin","nodeId":"rx-e2e-button"}
+[console] LOG: [StageCrew update] #rx-e2e-button {"classes":{"remove":["rx-comp-draggable"],"add":["rx-comp-grabbing"]},"style":{"touchAction":"none","willChange":"transform"}}
+[console] LOG: [StageCrew commit] {}
+[console] LOG: [Conductor play] Canvas.component-drag-symphony {"elementId":"rx-e2e-button","origin":{"x":0,"y":0}}
+[console] LOG: [StageCrew beginBeat] drag:frame:rx-e2e-button {"handlerName":"dragFrame","plugin":"canvas-ui-plugin","nodeId":"rx-e2e-button"}
+[console] LOG: [StageCrew update] #rx-e2e-button {"classes":{"remove":["rx-comp-draggable"],"add":["rx-comp-grabbing"]},"style":{"transform":"translate3d(12px, 9px, 0)"}}
+[console] LOG: [StageCrew commit] {}
+[console] LOG: [Conductor play] Canvas.component-drag-symphony {"elementId":"rx-e2e-button","delta":{"dx":12,"dy":9}}
+[console] LOG: [StageCrew beginBeat] drag:end:rx-e2e-button {"handlerName":"dragEnd","plugin":"canvas-ui-plugin","nodeId":"rx-e2e-button"}
+[console] LOG: [StageCrew update] #rx-e2e-button {"classes":{"remove":["rx-comp-grabbing"],"add":["rx-comp-draggable"]},"style":{"willChange":"","touchAction":"","transform":""}}
+[console] LOG: [StageCrew commit] {}
+[console] LOG: [StageCrew beginBeat] instance:pos:rx-e2e-button {"handlerName":"commitNodePosition","plugin":"canvas-ui-plugin","nodeId":"rx-e2e-button"}
+[console] LOG: [StageCrew upsertStyleTag] component-instance-css-rx-e2e-button .rx-e2e-button{position:absolute;left:22px;top:29px;box-sizing:border-box;display:block;}
+[console] LOG: [StageCrew commit] {}
+[console] LOG: [E2E] done
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renderx-plugins",
-  "version": "1.1.1",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "renderx-plugins",
-      "version": "1.1.1",
+      "version": "1.1.4",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   "license": "MIT",
   "type": "commonjs",
   "scripts": {
+    "dev": "node ./scripts/dev-server.cjs",
     "test": "jest --passWithNoTests",
     "test:ci": "jest --ci",
+    "e2e": "playwright test",
     "build:plugins": "node ./scripts/build-plugins.mjs",
     "build:manifest": "node ./scripts/generate-manifest.mjs",
     "build": "npm run build:plugins && npm run build:manifest && node ./scripts/build-bundles.mjs"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-extended": "^3.2.4",
     "jsdom": "^26.1.0",
+    "@playwright/test": "^1.40.0",
     "playwright": "^1.40.0",
     "ts-jest": "^29.4.1",
     "typescript": "^5.9.2"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-extended": "^3.2.4",
     "jsdom": "^26.1.0",
+    "playwright": "^1.40.0",
     "ts-jest": "^29.4.1",
     "typescript": "^5.9.2"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  testMatch: ['**/*.spec.ts'],
+  reporter: [['list']],
+  use: {
+    // We launch browser manually in tests, so keep default minimal context options
+    headless: true,
+  },
+});
+

--- a/scripts/dev-server.cjs
+++ b/scripts/dev-server.cjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 5007;
+const ROOT = process.cwd();
+
+const MIME = new Map(Object.entries({
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif'
+}));
+
+function safeJoin(base, target) {
+  const p = path.join(base, target);
+  const rel = path.relative(base, p);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  return p;
+}
+
+const server = http.createServer((req, res) => {
+  try {
+    const url = decodeURIComponent(req.url || '/');
+    let filePath = url.split('?')[0];
+    if (filePath.endsWith('/')) filePath += 'index.html';
+    const abs = safeJoin(ROOT, filePath);
+    if (!abs) {
+      res.writeHead(400); res.end('Bad Request'); return;
+    }
+    fs.stat(abs, (err, stat) => {
+      if (err || !stat.isFile()) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not Found');
+        return;
+      }
+      const ext = path.extname(abs).toLowerCase();
+      const type = MIME.get(ext) || 'application/octet-stream';
+      res.writeHead(200, {
+        'Content-Type': type,
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Access-Control-Allow-Origin': '*',
+      });
+      fs.createReadStream(abs).pipe(res);
+    });
+  } catch (e) {
+    res.writeHead(500, { 'Content-Type': 'text/plain' });
+    res.end('Server error');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`[dev-server] Listening on http://localhost:${PORT}`);
+});
+

--- a/tests/e2e/drag-stagecrew.html
+++ b/tests/e2e/drag-stagecrew.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Drag StageCrew E2E</title>
+    <style>
+      body { font-family: sans-serif; }
+      .app { position: relative; width: 800px; height: 600px; border: 1px solid #ccc; margin: 16px auto; }
+    </style>
+    <script>
+      // Simple console tap to also mirror logs to DOM for debugging if needed
+      (function(){
+        const orig = console.log;
+        const acc = [];
+        console.log = function(...args){ try { acc.push(args.map(String).join(' ')); } catch{}; orig.apply(console, args); };
+        window.__logs__ = acc;
+      })();
+    </script>
+  </head>
+  <body>
+    <div class="app">
+      <div id="root"></div>
+    </div>
+
+    <script type="module">
+      // Minimal React stub for plugin's expected API
+      window.React = {
+        createElement: (type, props, ...children) => ({ type, props: props || {}, children }),
+        useEffect: (fn) => fn(),
+        useState: (init) => [init, () => {}],
+        cloneElement: (el, p) => ({ ...el, props: { ...(el.props||{}), ...(p||{}) } }),
+      };
+
+      // StageCrew recorder that logs beginBeat/update/commit
+      function makeStageCrew() {
+        return {
+          beginBeat(corrId, meta){
+            console.log('[StageCrew beginBeat]', corrId, JSON.stringify(meta||{}));
+            const txn = {
+              update(selector, payload){ console.log('[StageCrew update]', selector, JSON.stringify(payload||{})); return txn; },
+              upsertStyleTag(id, cssText){ console.log('[StageCrew upsertStyleTag]', id, String(cssText||'').slice(0, 120)); return txn; },
+              commit(options){ console.log('[StageCrew commit]', JSON.stringify(options||{})); },
+            };
+            return txn;
+          }
+        };
+      }
+
+      // Conductor stub
+      window.renderxCommunicationSystem = {
+        conductor: {
+          play: (a,b,payload) => console.log('[Conductor play]', a, JSON.stringify(payload||{})),
+          getStageCrew: () => makeStageCrew(),
+        },
+        stageCrew: makeStageCrew(),
+      };
+
+      // Utility to render plugin CanvasPage output into real DOM
+      function renderToDom(vnode, container) {
+        if (!vnode) return null;
+        if (typeof vnode === 'string') { const tn = document.createTextNode(vnode); container.appendChild(tn); return tn; }
+        const el = document.createElement(vnode.type || 'div');
+        const props = vnode.props || {};
+        for (const [k, v] of Object.entries(props)) {
+          if (k === 'className') el.setAttribute('class', v);
+          else if (k === 'id') el.id = v;
+          else if (k.startsWith('on')) el[k.toLowerCase()] = v;
+          else el.setAttribute(k, String(v));
+        }
+        (vnode.children||[]).forEach(child => renderToDom(child, el));
+        container.appendChild(el);
+        return el;
+      }
+
+      import * as plugin from '../../plugins/canvas-ui-plugin/index.js';
+
+      // Define a node to render
+      const node = {
+        id: 'rx-e2e-button',
+        cssClass: 'rx-e2e-button',
+        type: 'button',
+        position: { x: 10, y: 20 },
+        component: {
+          metadata: { name: 'Button', type: 'button' },
+          ui: { template: '<button class="rx-button">OK</button>', styles: { css: '.rx-button{color:#000}' } },
+          integration: { canvasIntegration: { defaultWidth: 100, defaultHeight: 30 } },
+        },
+      };
+
+      // Render page and node
+      const tree = plugin.CanvasPage({ nodes: [node], selectedId: node.id });
+      const root = document.getElementById('root');
+      renderToDom(tree, root);
+      const nodeElVNode = plugin.renderCanvasNode(node);
+      const nodeEl = renderToDom(nodeElVNode, root);
+
+      // Simulate a drag: down -> move -> up
+      function dispatchPointer(el, type, init){
+        const ev = new PointerEvent(type, { bubbles: true, cancelable: true, ...init });
+        el.dispatchEvent(ev);
+      }
+
+      // Some handlers rely on .currentTarget from React; we installed to DOM as onpointer* properties
+      // Dispatch native events which call the same handlers
+      setTimeout(() => {
+        dispatchPointer(nodeEl, 'pointerdown', { clientX: 0, clientY: 0, pointerId: 1 });
+        dispatchPointer(nodeEl, 'pointermove', { clientX: 12, clientY: 9, buttons: 1 });
+        requestAnimationFrame(() => {
+          setTimeout(() => {
+            dispatchPointer(nodeEl, 'pointerup', { clientX: 12, clientY: 9, pointerId: 1 });
+            console.log('[E2E] done');
+          }, 20);
+        });
+      }, 50);
+    </script>
+  </body>
+</html>
+

--- a/tests/e2e/drag-stagecrew.spec.ts
+++ b/tests/e2e/drag-stagecrew.spec.ts
@@ -11,7 +11,7 @@ function timestamp() {
 }
 
 async function saveConsoleLog(logs: string[]) {
-  const dir = path.resolve(process.cwd(), '.logs');
+  const dir = path.resolve(process.cwd(), 'docs');
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   const p = path.join(dir, `console.${timestamp()}.log`);
   fs.writeFileSync(p, logs.join('\n'), 'utf8');

--- a/tests/e2e/drag-stagecrew.spec.ts
+++ b/tests/e2e/drag-stagecrew.spec.ts
@@ -11,7 +11,7 @@ function timestamp() {
 }
 
 async function saveConsoleLog(logs: string[]) {
-  const dir = path.resolve(process.cwd(), 'docs');
+  const dir = path.resolve(process.cwd(), 'docs/logs');
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   const p = path.join(dir, `console.${timestamp()}.log`);
   fs.writeFileSync(p, logs.join('\n'), 'utf8');

--- a/tests/e2e/drag-stagecrew.spec.ts
+++ b/tests/e2e/drag-stagecrew.spec.ts
@@ -1,3 +1,4 @@
+import { test, expect } from '@playwright/test';
 import { chromium, Page, LaunchOptions } from 'playwright';
 import fs from 'fs';
 import path from 'path';
@@ -18,6 +19,9 @@ function findChromiumExecutable(): string | null {
     const candidate = path.join(base, latest, 'chrome-linux', 'chrome');
     if (fs.existsSync(candidate)) return candidate;
   } catch {}
+  // Try common system paths for option #2
+  const systemCandidates = ['/usr/bin/chromium-browser', '/usr/bin/chromium', '/usr/bin/google-chrome', '/usr/bin/google-chrome-stable'];
+  for (const c of systemCandidates) { try { if (fs.existsSync(c)) return c; } catch {} }
   return null;
 }
 
@@ -35,16 +39,16 @@ async function saveConsoleLog(logs: string[]) {
   return p;
 }
 
-describe('E2E: Drag StageCrew commits appear in console logs', () => {
+test.describe('E2E: Drag StageCrew commits appear in console logs', () => {
   let browser: any;
 
-  beforeAll(async () => {
+  test.beforeAll(async () => {
     const execPath = findChromiumExecutable();
     const launchOptions: LaunchOptions = execPath ? { executablePath: execPath } : {};
     browser = await chromium.launch(launchOptions);
   });
 
-  afterAll(async () => {
+  test.afterAll(async () => {
     await browser?.close();
   });
 

--- a/tests/e2e/drag-stagecrew.spec.ts
+++ b/tests/e2e/drag-stagecrew.spec.ts
@@ -1,0 +1,59 @@
+import { chromium, Page } from 'playwright';
+import fs from 'fs';
+import path from 'path';
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 5007;
+
+function timestamp() {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}_${pad(d.getHours())}-${pad(d.getMinutes())}-${pad(d.getSeconds())}`;
+}
+
+async function saveConsoleLog(logs: string[]) {
+  const dir = path.resolve(process.cwd(), '.logs');
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const p = path.join(dir, `console.${timestamp()}.log`);
+  fs.writeFileSync(p, logs.join('\n'), 'utf8');
+  return p;
+}
+
+describe('E2E: Drag StageCrew commits appear in console logs', () => {
+  let browser: any;
+
+  beforeAll(async () => {
+    browser = await chromium.launch();
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+
+  test('drag emits StageCrew beginBeat/update/commit and saves log', async () => {
+    const context = await browser.newContext();
+    const page: Page = await context.newPage();
+    const consoleLines: string[] = [];
+
+    page.on('console', (msg) => {
+      consoleLines.push(`[console] ${msg.type().toUpperCase()}: ${msg.text()}`);
+    });
+
+    await page.goto(`http://localhost:${PORT}/tests/e2e/drag-stagecrew.html`);
+
+    // Wait for completion marker
+    await page.waitForFunction(() => Array.isArray((window as any).__logs__) && (window as any).__logs__.some((l: string) => /\[E2E\] done/.test(l)), null, { timeout: 5000 });
+
+    // Save and assert logs
+    const logPath = await saveConsoleLog(consoleLines);
+
+    const hasBegin = consoleLines.some(l => /\[StageCrew beginBeat\]/.test(l));
+    const hasUpdate = consoleLines.some(l => /\[StageCrew update\]/.test(l));
+    const hasCommit = consoleLines.some(l => /\[StageCrew commit\]/.test(l));
+
+    expect(hasBegin && hasUpdate && hasCommit).toBe(true);
+
+    // Expose log path for manual review
+    console.log(`[E2E] logs saved to: ${logPath}`);
+  });
+});
+

--- a/tests/unit/plugins/canvas-ui-plugin-drag-stagecrew-contract.test.ts
+++ b/tests/unit/plugins/canvas-ui-plugin-drag-stagecrew-contract.test.ts
@@ -1,0 +1,116 @@
+import { loadRenderXPlugin } from "../../utils/renderx-plugin-loader";
+import { TestEnvironment } from "../../utils/test-helpers";
+
+/**
+ * Verifies StageCrew commit contract during drag and overlay CSS scoping
+ * Issue: #21 - Missing StageCrew commits during drag; overlay spans canvas
+ */
+
+describe("Canvas UI drag - StageCrew commit contract and overlay scoping", () => {
+  function makeNode() {
+    return {
+      id: "rx-drag-sc",
+      cssClass: "rx-drag-sc",
+      type: "button",
+      position: { x: 10, y: 20 },
+      component: {
+        metadata: { name: "Button", type: "button" },
+        ui: { template: '<button class="rx-button">OK</button>', styles: { css: ".rx-button{color:#000}" } },
+        integration: { canvasIntegration: { defaultWidth: 100, defaultHeight: 30 } },
+      },
+    } as any;
+  }
+
+  test("onPointerDown/move/up use StageCrew beginBeat/update/commit and commit instance position; overlay CSS is per-instance", async () => {
+    // Reset head and window
+    while (document.head.firstChild) document.head.removeChild(document.head.firstChild);
+    (global as any).window = (global as any).window || {};
+
+    // Conductor and StageCrew recorder
+    const eventBus = TestEnvironment.createEventBus();
+    const conductor = TestEnvironment.createMusicalConductor(eventBus as any);
+    const ops: any[] = [];
+    const beginBeat = jest.fn((corrId: string, meta: any) => {
+      const txn: any = {
+        update: jest.fn((selector: string, payload: any) => { ops.push({ type: "update", selector, payload }); return txn; }),
+        upsertStyleTag: jest.fn((id: string, cssText: string) => { ops.push({ type: "upsertStyleTag", id, cssText }); return txn; }),
+        commit: jest.fn((options?: any) => { ops.push({ type: "commit", options }); return undefined; }),
+      };
+      ops.push({ type: "beginBeat", corrId, meta });
+      return txn;
+    });
+
+    (global as any).window.renderxCommunicationSystem = { conductor, stageCrew: { beginBeat }, __ops: ops } as any;
+
+    // React stub
+    const created: any[] = [];
+    (global as any).window.React = {
+      createElement: (type: any, props: any, ...children: any[]) => { const el = { type, props, children }; created.push(el); return el; },
+      useEffect: (fn: any) => fn(),
+      useState: (init: any) => [init, () => {}],
+      cloneElement: (el: any, p?: any) => ({ ...el, props: { ...(el.props||{}), ...(p||{}) } }),
+    } as any;
+
+    const plugin: any = loadRenderXPlugin("RenderX/public/plugins/canvas-ui-plugin/index.js");
+
+    const node = makeNode();
+
+    // Render page with selection so overlay is ensured via StageCrew
+    created.length = 0;
+    plugin.CanvasPage({ nodes: [node], selectedId: node.id });
+
+    // Assert overlay instance CSS was upserted via StageCrew and is scoped to instance (not full canvas)
+    const overlayUpsert = ops.find((o) => o.type === "upsertStyleTag" && o.id === `overlay-css-${node.id}`);
+    expect(overlayUpsert).toBeTruthy();
+    const overlayCss = String(overlayUpsert?.cssText || "").replace(/\s+/g, "");
+    expect(overlayCss).toContain(`.rx-overlay-${node.id}{`.replace(/\s+/g, ""));
+    expect(overlayCss).toContain(`width:100px`.replace(/\s+/g, ""));
+    expect(overlayCss).toContain(`height:30px`.replace(/\s+/g, ""));
+
+    // Render element to get drag handlers
+    const el = plugin.renderCanvasNode(node);
+    const domEl = document.createElement("div");
+
+    // Start drag
+    el.props.onPointerDown({ currentTarget: domEl, clientX: 0, clientY: 0, pointerId: 1, target: { setPointerCapture(){} }, stopPropagation(){} });
+
+    // Move by (7, 9) and allow rAF to flush
+    el.props.onPointerMove({ currentTarget: domEl, clientX: 7, clientY: 9 });
+    await new Promise((r) => setTimeout(r, 25));
+
+    // End drag
+    el.props.onPointerUp({ currentTarget: domEl, clientX: 7, clientY: 9, pointerId: 1, target: { releasePointerCapture(){} } });
+
+    // Assertions: StageCrew beginBeat/update/commit for start
+    const startBeat = ops.find((o) => o.type === "beginBeat" && /drag:start:/.test(o.corrId));
+    expect(startBeat).toBeTruthy();
+    expect(ops.some((o, i) => o.type === "beginBeat" && /drag:start:/.test(o.corrId) && ops.slice(i+1).some(p => p.type === "commit"))).toBe(true);
+
+    // Assertions: StageCrew beginBeat/update/commit for a frame
+    const frameBeatIdx = ops.findIndex((o) => o.type === "beginBeat" && /drag:frame:/.test(o.corrId));
+    expect(frameBeatIdx).toBeGreaterThanOrEqual(0);
+    const frameUpdate = ops.slice(frameBeatIdx + 1).find((o) => o.type === "update");
+    expect(frameUpdate).toBeTruthy();
+    expect((frameUpdate as any).selector).toBe(`#${node.id}`);
+    expect(String((frameUpdate as any).payload?.style?.transform || "")).toMatch(/translate3d\(7px,\s*9px,\s*0\)/);
+    const frameHasCommit = ops.slice(frameBeatIdx + 1).some((o) => o.type === "commit");
+    expect(frameHasCommit).toBe(true);
+
+    // Assertions: StageCrew beginBeat/commit for end
+    const endBeat = ops.find((o) => o.type === "beginBeat" && /drag:end:/.test(o.corrId));
+    expect(endBeat).toBeTruthy();
+    expect(ops.some((o, i) => o.type === "beginBeat" && /drag:end:/.test(o.corrId) && ops.slice(i+1).some(p => p.type === "commit"))).toBe(true);
+
+    // Assertions: instance position committed via upsert after end (10+7, 20+9) = (17, 29)
+    const instPosUpsert = [...ops].reverse().find((o) => o.type === "upsertStyleTag" && o.id === `component-instance-css-${node.id}`);
+    expect(instPosUpsert).toBeTruthy();
+    const instCss = String(instPosUpsert?.cssText || "").replace(/\s+/g, "");
+    expect(instCss).toContain(`.${node.cssClass}{position:absolute;left:17px;top:29px;`.replace(/\s+/g, ""));
+
+    // Also ensure the instance position beat was committed
+    const posBeatIdx = ops.findIndex((o) => o.type === "beginBeat" && o.corrId === `instance:pos:${node.id}`);
+    expect(posBeatIdx).toBeGreaterThanOrEqual(0);
+    expect(ops.slice(posBeatIdx + 1).some((o) => o.type === "commit")).toBe(true);
+  });
+});
+


### PR DESCRIPTION
Adds a minimal dev server and Playwright e2e test to verify StageCrew commits during drag and save a timestamped console log.

- scripts/dev-server.cjs (npm run dev)
- tests/e2e/drag-stagecrew.html (E2E harness page)
- tests/e2e/drag-stagecrew.spec.ts (Playwright test; saves .logs/console.<timestamp>.log)
- package.json scripts: dev, e2e

How to run
1. npm run dev
2. In another terminal: npm run e2e

Expected
- The Playwright test will drive a drag, capture console logs, save to .logs/console.<timestamp>.log, and assert that StageCrew beginBeat/update/commit logs are present.

Context: #21

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author