### PR TITLE
feat(#21): move drag StageCrew ops into handlers; thin UI drag listeners and route via play()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renderx-plugins",
-  "version": "1.1.8",
+  "version": "1.2.1",
   "private": false,
   "description": "RenderX plugins meta-package with unit tests and build + manifest generation",
   "files": [
@@ -14,6 +14,7 @@
     "test": "jest --passWithNoTests",
     "test:ci": "jest --ci",
     "e2e": "playwright test",
+    "prebuild": "node ./scripts/prebuild-version.mjs",
     "build:plugins": "node ./scripts/build-plugins.mjs",
     "build:manifest": "node ./scripts/generate-manifest.mjs",
     "build:sync-plugins-manifest": "node ./scripts/update-plugins-manifest.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renderx-plugins",
-  "version": "1.1.5",
+  "version": "1.1.8",
   "private": false,
   "description": "RenderX plugins meta-package with unit tests and build + manifest generation",
   "files": [

--- a/plugins/canvas-drag-plugin/index.js
+++ b/plugins/canvas-drag-plugin/index.js
@@ -61,21 +61,77 @@ export const sequence = {
 };
 
 export const handlers = {
-  handleDragStart: ({ elementId, origin }, ctx) => ({
-    drag: { elementId, origin },
-  }),
+  handleDragStart: ({ elementId, origin }, ctx) => {
+    const res = { drag: { elementId, origin } };
+    try {
+      const sc = ctx && ctx.stageCrew;
+      if (sc && typeof sc.beginBeat === "function") {
+        const txn = sc.beginBeat(`drag:start:${elementId}`, {
+          handlerName: "handleDragStart",
+          plugin: "canvas-drag-plugin",
+          sequenceId: ctx?.sequence?.id,
+          nodeId: elementId,
+        });
+        txn.update(`#${elementId}`, {
+          classes: { remove: ["rx-comp-draggable"], add: ["rx-comp-grabbing"] },
+          style: { touchAction: "none", willChange: "transform" },
+        });
+        txn.commit();
+      }
+    } catch {}
+    return res;
+  },
   handleDragMove: ({ elementId, delta, onDragUpdate }, ctx) => {
-    const o = ctx.payload.drag?.origin || { x: 0, y: 0 };
-    const position = { x: o.x + (delta?.dx || 0), y: o.y + (delta?.dy || 0) };
+    const o = (ctx && ctx.payload && ctx.payload.drag && ctx.payload.drag.origin) || { x: 0, y: 0 };
+    const dx = Math.round(delta?.dx || 0);
+    const dy = Math.round(delta?.dy || 0);
+    const position = { x: o.x + dx, y: o.y + dy };
+    try {
+      const sc = ctx && ctx.stageCrew;
+      if (sc && typeof sc.beginBeat === "function") {
+        const txn = sc.beginBeat(`drag:frame:${elementId}`, {
+          handlerName: "handleDragMove",
+          plugin: "canvas-drag-plugin",
+          sequenceId: ctx?.sequence?.id,
+          nodeId: elementId,
+        });
+        txn.update(`#${elementId}`, {
+          classes: { remove: ["rx-comp-draggable"], add: ["rx-comp-grabbing"] },
+          style: { transform: `translate3d(${dx}px, ${dy}px, 0)` },
+        });
+        txn.commit();
+      }
+    } catch {}
     try {
       onDragUpdate?.({ elementId, position });
     } catch {}
     return { elementId, position };
   },
-  handleDragEnd: ({ elementId, onDragEnd }, ctx) => {
+  handleDragEnd: ({ elementId, position, instanceClass, onDragEnd }, ctx) => {
     try {
-      onDragEnd?.({ elementId });
+      const sc = ctx && ctx.stageCrew;
+      if (sc && typeof sc.beginBeat === "function") {
+        const cls = String(instanceClass || elementId || "");
+        const txn = sc.beginBeat(`instance:pos:${elementId}`, {
+          handlerName: "handleDragEnd",
+          plugin: "canvas-drag-plugin",
+          sequenceId: ctx?.sequence?.id,
+          nodeId: elementId,
+        });
+        // Clear inline transform/classes on the element
+        txn.update(`#${elementId}`, {
+          classes: { add: ["rx-comp-draggable"], remove: ["rx-comp-grabbing"] },
+          style: { transform: "", willChange: "", touchAction: "" },
+        });
+        // Upsert per-instance position CSS
+        const x = Math.round(position?.x || 0);
+        const y = Math.round(position?.y || 0);
+        const cssText = `.${cls}{position:absolute;left:${x}px;top:${y}px;box-sizing:border-box;display:block;}`;
+        txn.upsertStyleTag(`component-instance-css-${elementId}`, cssText);
+        txn.commit();
+      }
     } catch {}
+    try { onDragEnd?.({ elementId, position }); } catch {}
     return {};
   },
 };

--- a/plugins/canvas-ui-plugin/handlers/drag.js
+++ b/plugins/canvas-ui-plugin/handlers/drag.js
@@ -3,10 +3,7 @@
 import { ensureCursorStylesInjected } from "../styles/cursors.js";
 
 import { DragCoordinator } from "../utils/DragCoordinator.js";
-import {
-  buildInstancePositionCssText,
-  updateInstancePositionCSS,
-} from "../styles/instanceCss.js";
+import { buildInstancePositionCssText } from "../styles/instanceCss.js";
 
 export function attachDragHandlers(node, deps = {}) {
   ensureCursorStylesInjected();
@@ -26,19 +23,7 @@ export function attachDragHandlers(node, deps = {}) {
     };
   };
 
-  // Resolve StageCrew from injected deps, handler ctx, or the global system
-  const resolveStageCrew = () => {
-    try {
-      if (deps?.stageCrew) return deps.stageCrew;
-      if (deps?.ctx?.stageCrew) return deps.ctx.stageCrew;
-      const system =
-        (typeof window !== "undefined" && window.renderxCommunicationSystem) ||
-        null;
-      return system?.stageCrew || system?.conductor?.getStageCrew?.() || null;
-    } catch {
-      return null;
-    }
-  };
+
 
   const play = (id, payload) => {
     try {
@@ -92,8 +77,7 @@ export function attachDragHandlers(node, deps = {}) {
     onPointerDown: (e) => {
       try {
         e?.stopPropagation?.();
-        // Prefer StageCrew for UI state classes/styles when available
-        const stageCrew = resolveStageCrew();
+        // Begin drag: minimal local affordance; StageCrew work occurs in handlers
         try {
           e.target?.setPointerCapture?.(e.pointerId);
         } catch {}
@@ -113,34 +97,15 @@ export function attachDragHandlers(node, deps = {}) {
           rafScheduled: false,
           el: e.currentTarget || null,
         });
-        if (stageCrew?.beginBeat) {
-          try {
-            const txn = stageCrew.beginBeat(`drag:start:${node.id}`, {
-              handlerName: "dragStart",
-              plugin: "canvas-ui-plugin",
-              nodeId: node.id,
-            });
-            if (typeof txn.update === "function")
-              txn.update(`#${node.id}`, {
-                classes: {
-                  remove: ["rx-comp-draggable"],
-                  add: ["rx-comp-grabbing"],
-                },
-                style: { touchAction: "none", willChange: "transform" },
-              });
-            if (typeof txn.commit === "function") txn.commit();
-          } catch {}
-        } else {
-          // No StageCrew available: minimally toggle classes on the current target
-          try {
-            e.currentTarget?.classList?.remove("rx-comp-draggable");
-            e.currentTarget?.classList?.add("rx-comp-grabbing");
-            if (e.currentTarget && e.currentTarget.style) {
-              e.currentTarget.style.touchAction = "none";
-              e.currentTarget.style.willChange = "transform";
-            }
-          } catch {}
-        }
+        // Minimal local affordance; StageCrew-driven side effects now happen in handlers
+        try {
+          e.currentTarget?.classList?.remove("rx-comp-draggable");
+          e.currentTarget?.classList?.add("rx-comp-grabbing");
+          if (e.currentTarget && e.currentTarget.style) {
+            e.currentTarget.style.touchAction = "none";
+            e.currentTarget.style.willChange = "transform";
+          }
+        } catch {}
         // Notify UI overlay to hide handles during drag
         try {
           const w = (typeof window !== "undefined" && window) || {};
@@ -148,13 +113,12 @@ export function attachDragHandlers(node, deps = {}) {
           if (ui && typeof ui.onDragStart === "function")
             ui.onDragStart({ elementId: node.id });
         } catch {}
-        play("Canvas.component-drag-symphony", { elementId: node.id, origin });
+        play("Canvas.component-drag-symphony", { elementId: node.id, origin, event: "canvas:element:drag:start" });
       } catch {}
     },
 
     onPointerMove: (e) => {
       try {
-        const stageCrew = resolveStageCrew();
         const cur = { x: e.clientX || 0, y: e.clientY || 0 };
         const rec = getRec();
         if (!rec || !rec.active) return;
@@ -163,29 +127,7 @@ export function attachDragHandlers(node, deps = {}) {
           id: node.id,
           cursor: cur,
           onFrame: ({ dx, dy }) => {
-            // Apply visual transform and grabbing class via StageCrew
-            try {
-              if (stageCrew?.beginBeat) {
-                const txn = stageCrew.beginBeat(`drag:frame:${node.id}`, {
-                  handlerName: "dragFrame",
-                  plugin: "canvas-ui-plugin",
-                  nodeId: node.id,
-                });
-                txn.update(`#${node.id}`, {
-                  classes: {
-                    remove: ["rx-comp-draggable"],
-                    add: ["rx-comp-grabbing"],
-                  },
-                  style: {
-                    transform: `translate3d(${Math.round(dx)}px, ${Math.round(
-                      dy
-                    )}px, 0)`,
-                  },
-                });
-                txn.commit();
-              }
-            } catch {}
-            // Notify overlay via callback and play move once per frame
+            // StageCrew side effects moved to handler; here we only emit play once per frame
             try {
               const w = (typeof window !== "undefined" && window) || {};
               const ui = w.__rx_canvas_ui__ || null;
@@ -193,14 +135,13 @@ export function attachDragHandlers(node, deps = {}) {
                 ui.onDragUpdate({ elementId: node.id, delta: { dx, dy } });
             } catch {}
             try {
-              const system =
-                (window && window.renderxCommunicationSystem) || null;
+              const system = (window && window.renderxCommunicationSystem) || null;
               const conductor = system && system.conductor;
               if (conductor && typeof conductor.play === "function") {
                 conductor.play(
                   "Canvas.component-drag-symphony",
                   "Canvas.component-drag-symphony",
-                  { elementId: node.id, delta: { dx, dy } }
+                  { elementId: node.id, delta: { dx, dy }, event: "canvas:element:moved" }
                 );
               }
             } catch {}
@@ -211,36 +152,16 @@ export function attachDragHandlers(node, deps = {}) {
 
     onPointerUp: (e) => {
       try {
-        const stageCrew = resolveStageCrew();
-        if (stageCrew?.beginBeat) {
-          try {
-            const txn = stageCrew.beginBeat(`drag:end:${node.id}`, {
-              handlerName: "dragEnd",
-              plugin: "canvas-ui-plugin",
-              nodeId: node.id,
-            });
-            if (typeof txn.update === "function")
-              txn.update(`#${node.id}`, {
-                classes: {
-                  remove: ["rx-comp-grabbing"],
-                  add: ["rx-comp-draggable"],
-                },
-                style: { willChange: "", touchAction: "", transform: "" },
-              });
-            if (typeof txn.commit === "function") txn.commit();
-          } catch {}
-        } else {
-          // No StageCrew available: restore classes inline on pointerup
-          try {
-            e.currentTarget?.classList?.remove("rx-comp-grabbing");
-            e.currentTarget?.classList?.add("rx-comp-draggable");
-            if (e.currentTarget && e.currentTarget.style) {
-              e.currentTarget.style.willChange = "";
-              e.currentTarget.style.touchAction = "";
-              e.currentTarget.style.transform = "";
-            }
-          } catch {}
-        }
+        // Minimal local affordance; StageCrew-driven cleanup happens in handlers
+        try {
+          e.currentTarget?.classList?.remove("rx-comp-grabbing");
+          e.currentTarget?.classList?.add("rx-comp-draggable");
+          if (e.currentTarget && e.currentTarget.style) {
+            e.currentTarget.style.willChange = "";
+            e.currentTarget.style.touchAction = "";
+            e.currentTarget.style.transform = "";
+          }
+        } catch {}
         try {
           e.target?.releasePointerCapture?.(e.pointerId);
         } catch {}
@@ -252,37 +173,20 @@ export function attachDragHandlers(node, deps = {}) {
           onCommit: (pos) => {
             try {
               const cls = String(node.cssClass || node.id || "");
-              if (stageCrew?.beginBeat) {
-                const txn = stageCrew.beginBeat(`instance:pos:${node.id}`, {
-                  handlerName: "commitNodePosition",
-                  plugin: "canvas-ui-plugin",
-                  nodeId: node.id,
-                });
-                const cssText = buildInstancePositionCssText(
-                  node.id,
-                  cls,
-                  pos.x,
-                  pos.y
-                );
-                if (typeof txn.upsertStyleTag === "function")
-                  txn.upsertStyleTag(
-                    "component-instance-css-" + node.id,
-                    cssText
-                  );
-                if (typeof txn.commit === "function") txn.commit();
-              } else {
-                // No StageCrew: update overlay and instance CSS directly for baseline persistence in tests
-                try {
-                  const cls = String(node.cssClass || node.id || "");
-                  updateInstancePositionCSS(node.id, cls, pos.x, pos.y);
-                  const w = (typeof window !== "undefined" && window) || {};
-                  const ui = w.__rx_canvas_ui__ || {};
-                  if (ui && ui.setSelectedId) {
-                    // Trigger overlay re-render path by toggling selection
-                    ui.setSelectedId(node.id);
-                  }
-                } catch {}
-              }
+              const cssText = buildInstancePositionCssText(
+                node.id,
+                cls,
+                pos.x,
+                pos.y
+              );
+              // Emit end with position and cssText for handler to persist via StageCrew
+              play("Canvas.component-drag-symphony", {
+                elementId: node.id,
+                position: pos,
+                instanceClass: cls,
+                cssText,
+                event: "canvas:element:drag:end",
+              });
             } catch {}
             try {
               const w = (typeof window !== "undefined" && window) || {};

--- a/plugins/canvas-ui-plugin/ui/overlay.js
+++ b/plugins/canvas-ui-plugin/ui/overlay.js
@@ -4,15 +4,17 @@ import {
 } from "../utils/styles.js";
 import { ResizeCoordinator } from "../utils/ResizeCoordinator.js";
 
-
 export function buildOverlayForNode(React, n, key, selectedId) {
   if (!(selectedId && (n.id === selectedId || n.elementId === selectedId)))
     return null;
   try {
-    // Ensure overlay global CSS via StageCrew (caller must supply in context)
-    const system = (typeof window !== "undefined" && window.renderxCommunicationSystem) || null;
+    // Ensure overlay global CSS via StageCrew (provide minimal sequence context)
+    const system =
+      (typeof window !== "undefined" && window.renderxCommunicationSystem) ||
+      null;
     const stageCrew = system?.stageCrew;
-    overlayEnsureGlobalCSS(stageCrew);
+    const ctx = { sequence: { id: "Canvas.ui-symphony" } };
+    overlayEnsureGlobalCSS(stageCrew, ctx);
     const defaults =
       (n.component &&
         n.component.integration &&
@@ -36,7 +38,13 @@ export function buildOverlayForNode(React, n, key, selectedId) {
       if (mw) w = parseFloat(mw[1]);
       if (mh) h = parseFloat(mh[1]);
     } catch {}
-    overlayEnsureInstanceCSS(stageCrew, { id: n.id, position: n.position }, w, h);
+    overlayEnsureInstanceCSS(
+      stageCrew,
+      { id: n.id, position: n.position },
+      w,
+      h,
+      ctx
+    );
   } catch {}
   const overlayClass = `rx-resize-overlay rx-overlay-${n.id || n.elementId}`;
   const handles = ["nw", "n", "ne", "e", "se", "s", "sw", "w"];

--- a/plugins/canvas-ui-plugin/utils/DragCoordinator.js
+++ b/plugins/canvas-ui-plugin/utils/DragCoordinator.js
@@ -26,13 +26,7 @@ function createDragCoordinator(win) {
         el: el || null,
       };
       setRec(id, rec);
-      // Apply drag affordances
-      try {
-        if (el && el.style) {
-          el.style.touchAction = "none";
-          el.style.willChange = "transform";
-        }
-      } catch {}
+      // Drag affordances are applied by StageCrew in canvas-drag-plugin handlers; no direct DOM writes here
     },
 
     move({ id, cursor, onFrame }) {
@@ -78,15 +72,7 @@ function createDragCoordinator(win) {
         x: (rec.start?.x || 0) + dx,
         y: (rec.start?.y || 0) + dy,
       };
-      // Clear affordances
-      try {
-        const el = rec.el;
-        if (el && el.style) {
-          el.style.transform = "";
-          el.style.willChange = "";
-          el.style.touchAction = "";
-        }
-      } catch {}
+      // Cleanup affordances is handled by StageCrew (handleDragEnd); no direct DOM writes here
       if (typeof onCommit === "function") {
         try {
           onCommit(finalPos);

--- a/plugins/manifest.json
+++ b/plugins/manifest.json
@@ -1,17 +1,17 @@
 {
-  "version": "1.1.8",
+  "version": "1.2.1",
   "plugins": [
     {
       "name": "Theme Management Plugin",
       "path": "theme-management-plugin/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Theme switching and management plugin for SPA integration",
       "autoMount": true
     },
     {
       "name": "Component Library Plugin",
       "path": "component-library-plugin/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Component library loading and preparation plugin",
       "autoMount": true,
       "ui": {
@@ -22,49 +22,49 @@
     {
       "name": "Library.component-drag-symphony",
       "path": "library-drag-plugin/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Handles drag start/end from the Element Library",
       "autoMount": true
     },
     {
       "name": "Library.component-drop-symphony",
       "path": "library-drop-plugin/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Handles library element drop onto the canvas and forwards create",
       "autoMount": true
     },
     {
       "name": "Canvas.component-create-symphony",
       "path": "canvas-create-plugin/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Creates a new canvas component on drop",
       "autoMount": true
     },
     {
       "name": "Canvas.component-select-symphony",
       "path": "canvas-selection-plugin/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Select/deselect a canvas component with callback updates",
       "autoMount": true
     },
     {
       "name": "Canvas.component-drag-symphony",
       "path": "canvas-drag-plugin/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Drag/move a canvas component with callback updates",
       "autoMount": true
     },
     {
       "name": "Canvas.component-resize-symphony",
       "path": "canvas-resize-plugin/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Resize a canvas component with callback updates",
       "autoMount": true
     },
     {
       "name": "Control Panel UI Plugin",
       "path": "control-panel-plugin/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Properties panel UI for the right slot",
       "autoMount": true,
       "ui": {
@@ -75,7 +75,7 @@
     {
       "name": "Canvas UI Plugin",
       "path": "canvas-ui-plugin/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Canvas UI (center slot) - scaffold",
       "autoMount": true,
       "ui": {
@@ -86,7 +86,7 @@
     {
       "name": "Header Left Branding",
       "path": "header/left/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Header left slot branding/status UI",
       "autoMount": false,
       "ui": {
@@ -97,7 +97,7 @@
     {
       "name": "Header Center Toggles",
       "path": "header/center/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Header center slot panel toggles UI",
       "autoMount": false,
       "ui": {
@@ -108,7 +108,7 @@
     {
       "name": "Header Right Controls",
       "path": "header/right/",
-      "version": "1.1.8",
+      "version": "1.2.1",
       "description": "Header right slot action buttons UI",
       "autoMount": false,
       "ui": {

--- a/plugins/manifest.json
+++ b/plugins/manifest.json
@@ -1,17 +1,17 @@
 {
-  "version": "1.1.5",
+  "version": "1.1.8",
   "plugins": [
     {
       "name": "Theme Management Plugin",
       "path": "theme-management-plugin/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Theme switching and management plugin for SPA integration",
       "autoMount": true
     },
     {
       "name": "Component Library Plugin",
       "path": "component-library-plugin/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Component library loading and preparation plugin",
       "autoMount": true,
       "ui": {
@@ -22,49 +22,49 @@
     {
       "name": "Library.component-drag-symphony",
       "path": "library-drag-plugin/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Handles drag start/end from the Element Library",
       "autoMount": true
     },
     {
       "name": "Library.component-drop-symphony",
       "path": "library-drop-plugin/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Handles library element drop onto the canvas and forwards create",
       "autoMount": true
     },
     {
       "name": "Canvas.component-create-symphony",
       "path": "canvas-create-plugin/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Creates a new canvas component on drop",
       "autoMount": true
     },
     {
       "name": "Canvas.component-select-symphony",
       "path": "canvas-selection-plugin/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Select/deselect a canvas component with callback updates",
       "autoMount": true
     },
     {
       "name": "Canvas.component-drag-symphony",
       "path": "canvas-drag-plugin/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Drag/move a canvas component with callback updates",
       "autoMount": true
     },
     {
       "name": "Canvas.component-resize-symphony",
       "path": "canvas-resize-plugin/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Resize a canvas component with callback updates",
       "autoMount": true
     },
     {
       "name": "Control Panel UI Plugin",
       "path": "control-panel-plugin/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Properties panel UI for the right slot",
       "autoMount": true,
       "ui": {
@@ -75,7 +75,7 @@
     {
       "name": "Canvas UI Plugin",
       "path": "canvas-ui-plugin/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Canvas UI (center slot) - scaffold",
       "autoMount": true,
       "ui": {
@@ -86,7 +86,7 @@
     {
       "name": "Header Left Branding",
       "path": "header/left/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Header left slot branding/status UI",
       "autoMount": false,
       "ui": {
@@ -97,7 +97,7 @@
     {
       "name": "Header Center Toggles",
       "path": "header/center/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Header center slot panel toggles UI",
       "autoMount": false,
       "ui": {
@@ -108,7 +108,7 @@
     {
       "name": "Header Right Controls",
       "path": "header/right/",
-      "version": "1.1.5",
+      "version": "1.1.8",
       "description": "Header right slot action buttons UI",
       "autoMount": false,
       "ui": {

--- a/scripts/prebuild-version.mjs
+++ b/scripts/prebuild-version.mjs
@@ -1,0 +1,93 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+/**
+ * Prebuild helper that optionally sets the package.json version if provided.
+ * Usage options (any one):
+ *   node ./scripts/prebuild-version.mjs --pkg-version 1.2.3
+ *   node ./scripts/prebuild-version.mjs --pkg-version=1.2.3
+ *   PKG_VERSION=1.2.3 node ./scripts/prebuild-version.mjs
+ *   npm run build -- --pkg-version=1.2.3   (relies on npm exposing npm_config_pkg_version)
+ */
+
+const root = process.cwd();
+const pkgPath = path.join(root, "package.json");
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a) continue;
+    if (a === "--pkg-version" && i + 1 < argv.length) {
+      out.pkgVersion = argv[i + 1];
+      i++;
+      continue;
+    }
+    if (a.startsWith("--pkg-version=")) {
+      out.pkgVersion = a.split("=")[1];
+      continue;
+    }
+  }
+  // Fallbacks via env
+  if (!out.pkgVersion && process.env.PKG_VERSION) {
+    out.pkgVersion = process.env.PKG_VERSION;
+  }
+  if (!out.pkgVersion && process.env.npm_config_pkg_version) {
+    out.pkgVersion = process.env.npm_config_pkg_version;
+  }
+  return out;
+}
+
+function isValidSemverLike(v) {
+  // Minimal check: allow numbers and dot + optional pre-release/build strings
+  // We rely on npm/yarn publish to further validate. Keep permissive for internal builds.
+  return (
+    typeof v === "string" && /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(v)
+  );
+}
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function writeFileWithRetry(file, text, tries = 6) {
+  let attempt = 0;
+  let lastErr;
+  while (attempt < tries) {
+    try {
+      await fs.writeFile(file, text, "utf8");
+      return;
+    } catch (e) {
+      lastErr = e;
+      if (e && (e.code === "EBUSY" || e.code === "EPERM")) {
+        const backoff = 25 * Math.pow(2, attempt); // 25ms, 50ms, 100ms, ...
+        await delay(backoff);
+        attempt++;
+        continue;
+      }
+      throw e;
+    }
+  }
+  throw lastErr;
+}
+
+async function maybeSetVersion() {
+  const { pkgVersion } = parseArgs(process.argv);
+  if (!pkgVersion) {
+    console.log("[prebuild-version] No --pkg-version provided; skipping.");
+    return;
+  }
+  if (!isValidSemverLike(pkgVersion)) {
+    console.error(`[prebuild-version] Invalid version: ${pkgVersion}`);
+    process.exit(1);
+  }
+
+  const pkg = JSON.parse(await fs.readFile(pkgPath, "utf8"));
+  pkg.version = pkgVersion;
+  const text = JSON.stringify(pkg, null, 2) + "\n";
+  await writeFileWithRetry(pkgPath, text);
+  console.log(`[prebuild-version] Set package.json version to ${pkgVersion}`);
+}
+
+maybeSetVersion().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/unit/build/prebuild-version.test.ts
+++ b/tests/unit/build/prebuild-version.test.ts
@@ -1,0 +1,75 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+
+/**
+ * Verifies that the prebuild script can set the package.json version when invoked
+ * with a --pkg-version flag or via npm run args before the rest of the build runs.
+ *
+ * Important: use a temporary working directory to avoid interfering with other
+ * parallel tests that might read/write the repo root package.json.
+ */
+describe("Build: prebuild sets package.json version when provided", () => {
+  const repoRoot = path.resolve(__dirname, "../../../");
+  const repoPkgPath = path.join(repoRoot, "package.json");
+  const prebuildScript = path.join(repoRoot, "scripts", "prebuild-version.mjs");
+  let originalPkgText: string;
+
+  beforeAll(() => {
+    originalPkgText = fs.readFileSync(repoPkgPath, "utf8");
+  });
+
+  afterAll(() => {
+    // Restore original package.json so the test is not destructive if any test
+    // accidentally wrote to the repo root.
+    fs.writeFileSync(repoPkgPath, originalPkgText, "utf8");
+  });
+
+  function withTempPkgJson(run: (cwd: string, pkgPath: string) => void) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rx-prebuild-"));
+    const tmpPkgPath = path.join(tmpDir, "package.json");
+    fs.writeFileSync(tmpPkgPath, originalPkgText, "utf8");
+    try {
+      run(tmpDir, tmpPkgPath);
+    } finally {
+      try {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+
+  test("prebuild script updates package.json version from --pkg-version", () => {
+    const testVersion = "9.9.9-test"; // a valid semver pre-release string
+
+    withTempPkgJson((cwd, pkgPath) => {
+      // Run the prebuild script directly with Node, passing the version flag
+      execFileSync(
+        process.execPath,
+        [prebuildScript, "--pkg-version", testVersion],
+        {
+          cwd,
+          stdio: "inherit",
+        }
+      );
+
+      // Verify package.json version changed
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+      expect(pkg.version).toBe(testVersion);
+    });
+  });
+
+  test("npm run build -- --pkg-version= also works (npm_config_pkg_version)", () => {
+    const testVersion = "8.8.8-rc.1";
+
+    withTempPkgJson((cwd, pkgPath) => {
+      execFileSync(process.execPath, [prebuildScript], {
+        cwd,
+        stdio: "inherit",
+        env: { ...process.env, npm_config_pkg_version: testVersion },
+      });
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+      expect(pkg.version).toBe(testVersion);
+    });
+  });
+});

--- a/tests/unit/flows/cursor-state-on-hover-and-grab.test.js
+++ b/tests/unit/flows/cursor-state-on-hover-and-grab.test.js
@@ -3,7 +3,8 @@ const { loadRenderXPlugin } = require("../../utils/renderx-plugin-loader");
 describe("Cursor policy: open hand on hover, closed fist on grab", () => {
   test("hover adds rx-comp-draggable; mousedown swaps to rx-comp-grabbing; mouseup restores", () => {
     // Reset head styles
-    while (document.head.firstChild) document.head.removeChild(document.head.firstChild);
+    while (document.head.firstChild)
+      document.head.removeChild(document.head.firstChild);
 
     // Stub React
     global.window = global.window || {};
@@ -12,31 +13,149 @@ describe("Cursor policy: open hand on hover, closed fist on grab", () => {
       createElement: (type, props, ...children) => ({ type, props, children }),
       useEffect: (fn) => fn(),
       useState: (init) => [init, () => {}],
-      cloneElement: (el, p) => ({ ...el, props: { ...(el.props||{}), ...(p||{}) } }),
+      cloneElement: (el, p) => ({
+        ...el,
+        props: { ...(el.props || {}), ...(p || {}) },
+      }),
     };
 
-    const plugin = loadRenderXPlugin("RenderX/public/plugins/canvas-ui-plugin/index.js");
-    const node = { id: "rx-cursor-1", cssClass: "rx-cursor-1", type: "button", position: { x: 0, y: 0 }, component: { metadata: { name: "Button", type: "button"}, ui: { template: '<button class="rx-button">OK</button>', styles: { css: '.rx-button{color:#000}' } }, integration: { canvasIntegration: { defaultWidth: 100, defaultHeight: 30 } } } };
+    const plugin = loadRenderXPlugin(
+      "RenderX/public/plugins/canvas-ui-plugin/index.js"
+    );
+    const node = {
+      id: "rx-cursor-1",
+      cssClass: "rx-cursor-1",
+      type: "button",
+      position: { x: 0, y: 0 },
+      component: {
+        metadata: { name: "Button", type: "button" },
+        ui: {
+          template: '<button class="rx-button">OK</button>',
+          styles: { css: ".rx-button{color:#000}" },
+        },
+        integration: {
+          canvasIntegration: { defaultWidth: 100, defaultHeight: 30 },
+        },
+      },
+    };
     const el = plugin.renderCanvasNode(node);
 
-    const domEl = document.createElement('div');
-    // Hover enter
+    // Wire conductor + StageCrew transform of hover/drag via canvas-drag-plugin
+    const { TestEnvironment } = require("../../utils/test-helpers");
+    const eventBus = TestEnvironment.createEventBus();
+    const conductor = TestEnvironment.createMusicalConductor(eventBus);
+    const dragPlugin = loadRenderXPlugin(
+      "RenderX/public/plugins/canvas-drag-plugin/index.js"
+    );
+    const beginBeat = (corrId, meta) => {
+      const txn = {
+        update: (selector, payload) => {
+          try {
+            let elem = null;
+            if (selector && selector.startsWith("#")) {
+              const id = selector.slice(1);
+              elem =
+                document.getElementById(id) ||
+                (window.__rx_drag &&
+                  window.__rx_drag[id] &&
+                  window.__rx_drag[id].el) ||
+                null;
+            }
+            if (elem) {
+              if (payload?.classes?.add)
+                payload.classes.add.forEach((c) => elem.classList.add(c));
+              if (payload?.classes?.remove)
+                payload.classes.remove.forEach((c) => elem.classList.remove(c));
+              if (payload?.style)
+                Object.entries(payload.style).forEach(([k, v]) => {
+                  elem.style[k] = v;
+                });
+            }
+          } catch {}
+          return txn;
+        },
+        commit: () => {},
+      };
+      return txn;
+    };
+    window.renderxCommunicationSystem = { conductor };
+    conductor.play = jest.fn((_p, seqId, payload) => {
+      if (seqId !== "Canvas.component-drag-symphony") return;
+      const ctx = {
+        payload: conductor.__ctxPayload || {},
+        stageCrew: { beginBeat },
+        sequence: dragPlugin.sequence,
+      };
+      const ev = payload?.event;
+      if (ev === "canvas:element:hover:enter") {
+        dragPlugin.handlers.handleHoverEnter(
+          { elementId: payload.elementId },
+          ctx
+        );
+      } else if (ev === "canvas:element:hover:leave") {
+        dragPlugin.handlers.handleHoverLeave(
+          { elementId: payload.elementId },
+          ctx
+        );
+      } else if (ev === "canvas:element:drag:start") {
+        const res = dragPlugin.handlers.handleDragStart(
+          { elementId: payload.elementId, origin: payload.origin },
+          ctx
+        );
+        conductor.__ctxPayload = { ...(ctx.payload || {}), ...(res || {}) };
+      } else if (ev === "canvas:element:moved") {
+        const res = dragPlugin.handlers.handleDragMove(
+          { elementId: payload.elementId, delta: payload.delta },
+          { ...ctx, payload: conductor.__ctxPayload || {} }
+        );
+        conductor.__ctxPayload = {
+          ...(conductor.__ctxPayload || {}),
+          ...(res || {}),
+        };
+      } else if (ev === "canvas:element:drag:end") {
+        dragPlugin.handlers.handleDragEnd(
+          {
+            elementId: payload.elementId,
+            position: payload.position,
+            instanceClass: payload.instanceClass,
+          },
+          { ...ctx, payload: conductor.__ctxPayload || {} }
+        );
+      }
+    });
+
+    const domEl = document.createElement("div");
+    domEl.id = node.id;
+    document.body.appendChild(domEl);
+    // Hover enter (handled by StageCrew via handlers)
     el.props.onPointerEnter({ currentTarget: domEl });
-    expect(domEl.classList.contains('rx-comp-draggable')).toBe(true);
-    expect(domEl.classList.contains('rx-comp-grabbing')).toBe(false);
+    expect(domEl.classList.contains("rx-comp-draggable")).toBe(true);
+    expect(domEl.classList.contains("rx-comp-grabbing")).toBe(false);
 
     // Grab (pointerdown)
-    el.props.onPointerDown({ currentTarget: domEl, clientX: 0, clientY: 0, pointerId: 1, target: { setPointerCapture(){} }, stopPropagation(){} });
-    expect(domEl.classList.contains('rx-comp-grabbing')).toBe(true);
-    expect(domEl.classList.contains('rx-comp-draggable')).toBe(false);
+    el.props.onPointerDown({
+      currentTarget: domEl,
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+      target: { setPointerCapture() {} },
+      stopPropagation() {},
+    });
+    expect(domEl.classList.contains("rx-comp-grabbing")).toBe(true);
+    expect(domEl.classList.contains("rx-comp-draggable")).toBe(false);
 
     // Release (pointerup)
-    el.props.onPointerUp({ currentTarget: domEl, clientX: 0, clientY: 0, pointerId: 1, target: { releasePointerCapture(){} } });
-    expect(domEl.classList.contains('rx-comp-grabbing')).toBe(false);
+    el.props.onPointerUp({
+      currentTarget: domEl,
+      clientX: 0,
+      clientY: 0,
+      pointerId: 1,
+      target: { releasePointerCapture() {} },
+    });
+    expect(domEl.classList.contains("rx-comp-grabbing")).toBe(false);
     // Draggable class is re-added on hover or maintained if still hovered
     // Ensure styles injected exist
-    const cursorGlobal = document.getElementById('rx-canvas-ui-cursors');
+    const cursorGlobal = document.getElementById("rx-canvas-ui-cursors");
     expect(cursorGlobal).not.toBeNull();
   });
 });
-

--- a/tests/unit/flows/selection-overlay-bounds-stagecrew.test.ts
+++ b/tests/unit/flows/selection-overlay-bounds-stagecrew.test.ts
@@ -1,0 +1,123 @@
+import { loadRenderXPlugin } from "../../utils/renderx-plugin-loader";
+import { TestEnvironment } from "../../utils/test-helpers";
+
+/**
+ * Red: Selection overlay must match selected component bounds (not full canvas)
+ * - Clicking a component should result in StageCrew ensuring overlay instance CSS positioned at the node's left/top with its default size
+ */
+
+describe("Selection overlay bounds via StageCrew", () => {
+  test("click to select applies overlay-css-<id> with correct left/top/width/height", async () => {
+    // Clean styles
+    while (document.head.firstChild)
+      document.head.removeChild(document.head.firstChild);
+
+    // Conductor + selection plugin mounted
+    const eventBus = TestEnvironment.createEventBus();
+    const conductor = TestEnvironment.createMusicalConductor(eventBus as any);
+    const selection: any = loadRenderXPlugin(
+      "RenderX/public/plugins/canvas-selection-plugin/index.js"
+    );
+    await conductor.mount(
+      selection.sequence,
+      selection.handlers,
+      selection.sequence.id
+    );
+
+    // Expose StageCrew recorder
+    const ops: any[] = [];
+    const beginBeat = jest.fn((corrId: string, meta: any) => {
+      const txn: any = {
+        update: jest.fn((selector: string, payload: any) => {
+          ops.push({ type: "update", selector, payload });
+          return txn;
+        }),
+        upsertStyleTag: jest.fn((id: string, cssText: string) => {
+          ops.push({ type: "style", id, cssText });
+          return txn;
+        }),
+        commit: jest.fn(() => {
+          ops.push({ type: "commit" });
+        }),
+      };
+      ops.push({ type: "beginBeat", corrId, meta });
+      return txn;
+    });
+    (global as any).window = (global as any).window || {};
+    (global as any).window.renderxCommunicationSystem = {
+      conductor,
+      stageCrew: { beginBeat },
+      __ops: ops,
+    } as any;
+
+    // React stub
+    const created: any[] = [];
+    (global as any).window.React = {
+      createElement: (type: any, props: any, ...children: any[]) => {
+        created.push({ type, props, children });
+        return { type, props, children };
+      },
+      useEffect: (fn: any) => fn(),
+      useState: (init: any) => [init, () => {}],
+      cloneElement: (el: any, p?: any) => ({
+        ...el,
+        props: { ...(el.props || {}), ...(p || {}) },
+      }),
+    } as any;
+
+    // Load UI plugin and render page with a single node
+    const ui: any = loadRenderXPlugin(
+      "RenderX/public/plugins/canvas-ui-plugin/index.js"
+    );
+    const node = {
+      id: "rx-comp-button-sel1",
+      cssClass: "rx-comp-button-sel1",
+      type: "button",
+      position: { x: 25, y: 35 },
+      component: {
+        metadata: { name: "Button", type: "button" },
+        ui: {
+          template: '<button class="rx-button">OK</button>',
+          styles: { css: ".rx-button{color:#000}" },
+        },
+        integration: {
+          canvasIntegration: { defaultWidth: 110, defaultHeight: 32 },
+        },
+      },
+    };
+
+    // Render
+    created.length = 0;
+    ui.CanvasPage({ nodes: [node], selectedId: node.id });
+
+    // Find the canvas node UI element and simulate click
+    const canvasEl = created.find(
+      (e) =>
+        e.type === "div" &&
+        String(e.props?.className || "").includes(node.cssClass)
+    );
+    expect(canvasEl).toBeTruthy();
+
+    // Click -> selection symphony (call handler directly)
+    const { onElementClick } = loadRenderXPlugin(
+      "RenderX/public/plugins/canvas-ui-plugin/handlers/select.js"
+    );
+    const clickHandler = onElementClick(node);
+    clickHandler({ stopPropagation() {} });
+
+    // Inspect StageCrew style ensure
+    const opsArr = (global as any).window.renderxCommunicationSystem
+      .__ops as any[];
+    const inst = opsArr.find(
+      (o) => o.type === "style" && o.id === `overlay-css-${node.id}`
+    );
+    expect(inst).toBeTruthy();
+    const css = String(inst.cssText || "").replace(/\s+/g, "");
+    expect(css).toContain(
+      `.rx-overlay-${node.id}{position:absolute;left:25px;top:35px;width:110px;height:32px;z-index:10;}`.replace(
+        /\s+/g,
+        ""
+      )
+    );
+  });
+});

--- a/tests/unit/flows/ui-drag-move-drop-e2e.test.js
+++ b/tests/unit/flows/ui-drag-move-drop-e2e.test.js
@@ -13,6 +13,113 @@ describe("UI E2E: canvas component drag start/move/end wiring", () => {
     const eventBus = TestEnvironment.createEventBus();
     const conductor = TestEnvironment.createMusicalConductor(eventBus);
     global.window = global.window || {};
+
+    // StageCrew DOM-applier + conductor.play routing to canvas-drag-plugin
+    const dragPlugin = loadRenderXPlugin(
+      "RenderX/public/plugins/canvas-drag-plugin/index.js"
+    );
+    const beginBeat = (corrId, meta) => {
+      const txn = {
+        update: (selector, payload) => {
+          try {
+            let el = null;
+            if (selector && selector.startsWith("#")) {
+              const id = selector.slice(1);
+              el =
+                document.getElementById(id) ||
+                (window.__rx_drag &&
+                  window.__rx_drag[id] &&
+                  window.__rx_drag[id].el) ||
+                null;
+            }
+            if (el) {
+              if (payload?.classes?.add)
+                payload.classes.add.forEach((c) => el.classList.add(c));
+              if (payload?.classes?.remove)
+                payload.classes.remove.forEach((c) => el.classList.remove(c));
+              if (payload?.style)
+                Object.entries(payload.style).forEach(([k, v]) => {
+                  el.style[k] = v;
+                });
+              if (payload?.attrs)
+                Object.entries(payload.attrs).forEach(([k, v]) => {
+                  if (k === "class") el.setAttribute("class", String(v || ""));
+                  else el.setAttribute(k, String(v || ""));
+                });
+            }
+          } catch {}
+          return txn;
+        },
+        upsertStyleTag: (id, cssText) => {
+          try {
+            let tag = document.getElementById(id);
+            if (!tag) {
+              tag = document.createElement("style");
+              tag.id = id;
+              document.head.appendChild(tag);
+            }
+            tag.textContent = String(cssText || "");
+          } catch {}
+          return txn;
+        },
+        commit: () => {},
+      };
+      return txn;
+    };
+
+    const origPlay = conductor.play;
+    conductor.play = jest.fn((_pluginId, seqId, payload) => {
+      if (seqId !== "Canvas.component-drag-symphony")
+        return origPlay.call(conductor, _pluginId, seqId, payload);
+      try {
+        console.log(
+          "PluginInterfaceFacade.play(): Canvas.component-drag-symphony"
+        );
+      } catch {}
+      const ctx = {
+        payload: conductor.__ctxPayload || {},
+        stageCrew: { beginBeat },
+        sequence: dragPlugin.sequence,
+      };
+      const ev = payload?.event;
+      if (ev === "canvas:element:hover:enter") {
+        dragPlugin.handlers.handleHoverEnter(
+          { elementId: payload.elementId },
+          ctx
+        );
+      } else if (ev === "canvas:element:hover:leave") {
+        dragPlugin.handlers.handleHoverLeave(
+          { elementId: payload.elementId },
+          ctx
+        );
+      } else if (ev === "canvas:element:drag:start") {
+        const res = dragPlugin.handlers.handleDragStart(
+          { elementId: payload.elementId, origin: payload.origin },
+          ctx
+        );
+        conductor.__ctxPayload = { ...(ctx.payload || {}), ...(res || {}) };
+      } else if (ev === "canvas:element:moved") {
+        const res = dragPlugin.handlers.handleDragMove(
+          { elementId: payload.elementId, delta: payload.delta },
+          { ...ctx, payload: conductor.__ctxPayload || {} }
+        );
+        conductor.__ctxPayload = {
+          ...(conductor.__ctxPayload || {}),
+          ...(res || {}),
+        };
+      } else if (ev === "canvas:element:drag:end") {
+        dragPlugin.handlers.handleDragEnd(
+          {
+            elementId: payload.elementId,
+            position: payload.position,
+            instanceClass: payload.instanceClass,
+          },
+          { ...ctx, payload: conductor.__ctxPayload || {} }
+        );
+      }
+      return Promise.resolve();
+    });
+
     window.renderxCommunicationSystem = { conductor };
 
     // Record logs to ensure drag symphony runs
@@ -85,6 +192,8 @@ describe("UI E2E: canvas component drag start/move/end wiring", () => {
 
       // Create a real DOM element to receive style transforms
       const domEl = document.createElement("div");
+      domEl.id = node.id;
+      document.body.appendChild(domEl);
 
       // Act 1: pointerdown at (100, 100)
       draggableEl.props.onPointerDown({

--- a/tests/unit/handlers/drag-hover-move-no-grab.test.ts
+++ b/tests/unit/handlers/drag-hover-move-no-grab.test.ts
@@ -21,6 +21,106 @@ describe("Drag handler - hover move must not set rx-comp-grabbing", () => {
       }),
     } as any;
 
+    const dragPlugin: any = loadRenderXPlugin(
+      "RenderX/public/plugins/canvas-drag-plugin/index.js"
+    );
+    const beginBeat = (corrId: string, meta: any) => {
+      const txn: any = {
+        update: (selector: string, payload: any) => {
+          try {
+            let el: any = null;
+            if (selector && selector.startsWith("#")) {
+              const id = selector.slice(1);
+              el =
+                document.getElementById(id) ||
+                ((window as any).__rx_drag &&
+                  (window as any).__rx_drag[id] &&
+                  (window as any).__rx_drag[id].el) ||
+                null;
+            }
+            if (el) {
+              if (payload?.classes?.add)
+                payload.classes.add.forEach((c: string) => el.classList.add(c));
+              if (payload?.classes?.remove)
+                payload.classes.remove.forEach((c: string) =>
+                  el.classList.remove(c)
+                );
+              if (payload?.style)
+                Object.entries(payload.style).forEach(([k, v]) => {
+                  el.style[k] = v as any;
+                });
+            }
+          } catch {}
+          return txn;
+        },
+        upsertStyleTag: (id: string, cssText: string) => {
+          try {
+            let tag = document.getElementById(id);
+            if (!tag) {
+              tag = document.createElement("style");
+              tag.id = id;
+              document.head.appendChild(tag);
+            }
+            tag.textContent = String(cssText || "");
+          } catch {}
+          return txn;
+        },
+        commit: () => {},
+      };
+      return txn;
+    };
+
+    (window as any).renderxCommunicationSystem = { conductor: {} } as any;
+    (window as any).renderxCommunicationSystem.conductor.play = jest.fn(
+      (_pluginId: string, seqId: string, payload: any) => {
+        if (seqId !== "Canvas.component-drag-symphony") return;
+        const ctx: any = {
+          payload: (window as any).__ctxPayload || {},
+          stageCrew: { beginBeat },
+          sequence: dragPlugin.sequence,
+        };
+        const ev = payload?.event;
+        if (ev === "canvas:element:hover:enter") {
+          dragPlugin.handlers.handleHoverEnter(
+            { elementId: payload.elementId },
+            ctx
+          );
+        } else if (ev === "canvas:element:hover:leave") {
+          dragPlugin.handlers.handleHoverLeave(
+            { elementId: payload.elementId },
+            ctx
+          );
+        } else if (ev === "canvas:element:drag:start") {
+          const res = dragPlugin.handlers.handleDragStart(
+            { elementId: payload.elementId, origin: payload.origin },
+            ctx
+          );
+          (window as any).__ctxPayload = {
+            ...(ctx.payload || {}),
+            ...(res || {}),
+          };
+        } else if (ev === "canvas:element:moved") {
+          const res = dragPlugin.handlers.handleDragMove(
+            { elementId: payload.elementId, delta: payload.delta },
+            { ...ctx, payload: (window as any).__ctxPayload || {} }
+          );
+          (window as any).__ctxPayload = {
+            ...((window as any).__ctxPayload || {}),
+            ...(res || {}),
+          };
+        } else if (ev === "canvas:element:drag:end") {
+          dragPlugin.handlers.handleDragEnd(
+            {
+              elementId: payload.elementId,
+              position: payload.position,
+              instanceClass: payload.instanceClass,
+            },
+            { ...ctx, payload: (window as any).__ctxPayload || {} }
+          );
+        }
+      }
+    );
+
     const plugin: any = loadRenderXPlugin(
       "RenderX/public/plugins/canvas-ui-plugin/index.js"
     );
@@ -42,15 +142,11 @@ describe("Drag handler - hover move must not set rx-comp-grabbing", () => {
     };
     const el = plugin.renderCanvasNode(node);
 
-    const backing = new Set<string>();
-    const domEl: any = {
-      classList: {
-        add: (c: string) => backing.add(c),
-        remove: (c: string) => backing.delete(c),
-        contains: (c: string) => backing.has(c),
-      },
-      style: {},
-    };
+    const domEl: any = document.createElement("div");
+
+    // Ensure StageCrew selector can resolve element by #id and retain currentTarget fallback
+    (domEl as any).id = node.id;
+    document.body.appendChild(domEl as unknown as Node);
 
     // Hover enter should mark draggable
     el.props.onPointerEnter({ currentTarget: domEl, buttons: 0 });

--- a/tests/unit/plugins/canvas-drag-plugin.test.ts
+++ b/tests/unit/plugins/canvas-drag-plugin.test.ts
@@ -67,4 +67,74 @@ describe("RenderX Canvas Drag Plugin", () => {
       expect(res).toEqual({});
     });
   });
+
+    test("handleDragStart performs StageCrew beginBeat/update/commit", () => {
+      const plugin: any = loadRenderXPlugin(pluginPath);
+      const ops: any[] = [];
+      const beginBeat = jest.fn((corrId: string, meta: any) => {
+        const txn: any = {
+          update: jest.fn((selector: string, payload: any) => { ops.push({ type: "update", selector, payload }); return txn; }),
+          upsertStyleTag: jest.fn((id: string, cssText: string) => { ops.push({ type: "upsertStyleTag", id, cssText }); return txn; }),
+          commit: jest.fn((options?: any) => { ops.push({ type: "commit", options }); return undefined; }),
+        };
+        ops.push({ type: "beginBeat", corrId, meta });
+        return txn;
+      });
+      const ctx: any = { payload: {}, stageCrew: { beginBeat }, sequence: plugin.sequence };
+      const origin = { x: 0, y: 0 };
+      plugin.handlers.handleDragStart({ elementId: "id1", origin }, ctx);
+      const startIdx = ops.findIndex((o) => o.type === "beginBeat" && /drag:start:id1/.test(o.corrId));
+      expect(startIdx).toBeGreaterThanOrEqual(0);
+      const update = ops.slice(startIdx + 1).find((o) => o.type === "update");
+      expect(update).toBeTruthy();
+      expect(update.selector).toBe("#id1");
+      expect(ops.slice(startIdx + 1).some((o) => o.type === "commit")).toBe(true);
+    });
+
+    test("handleDragMove performs StageCrew beginBeat/update/commit with transform", () => {
+      const plugin: any = loadRenderXPlugin(pluginPath);
+      const ops: any[] = [];
+      const beginBeat = jest.fn((corrId: string, meta: any) => {
+        const txn: any = {
+          update: jest.fn((selector: string, payload: any) => { ops.push({ type: "update", selector, payload }); return txn; }),
+          commit: jest.fn((options?: any) => { ops.push({ type: "commit", options }); return undefined; }),
+        };
+        ops.push({ type: "beginBeat", corrId, meta });
+        return txn;
+      });
+      const ctx: any = { payload: { drag: { origin: { x: 10, y: 20 } } }, stageCrew: { beginBeat }, sequence: plugin.sequence };
+      plugin.handlers.handleDragMove({ elementId: "id1", delta: { dx: 7, dy: 9 } }, ctx);
+      const frameIdx = ops.findIndex((o) => o.type === "beginBeat" && /drag:frame:id1/.test(o.corrId));
+      expect(frameIdx).toBeGreaterThanOrEqual(0);
+      const update = ops.slice(frameIdx + 1).find((o) => o.type === "update");
+      expect(update).toBeTruthy();
+      expect(update.selector).toBe("#id1");
+      expect(String(update.payload?.style?.transform || "")).toMatch(/translate3d\(7px,\s*9px,\s*0\)/);
+      expect(ops.slice(frameIdx + 1).some((o) => o.type === "commit")).toBe(true);
+    });
+
+    test("handleDragEnd clears transform, restores classes, and upserts instance position CSS", () => {
+      const plugin: any = loadRenderXPlugin(pluginPath);
+      const ops: any[] = [];
+      const beginBeat = jest.fn((corrId: string, meta: any) => {
+        const txn: any = {
+          update: jest.fn((selector: string, payload: any) => { ops.push({ type: "update", selector, payload }); return txn; }),
+          upsertStyleTag: jest.fn((id: string, cssText: string) => { ops.push({ type: "upsertStyleTag", id, cssText }); return txn; }),
+          commit: jest.fn((options?: any) => { ops.push({ type: "commit", options }); return undefined; }),
+        };
+        ops.push({ type: "beginBeat", corrId, meta });
+        return txn;
+      });
+      const ctx: any = { payload: {}, stageCrew: { beginBeat }, sequence: plugin.sequence };
+      plugin.handlers.handleDragEnd({ elementId: "id1", position: { x: 17, y: 29 }, instanceClass: "id1" }, ctx);
+      const posIdx = ops.findIndex((o) => o.type === "beginBeat" && o.corrId === "instance:pos:id1");
+      expect(posIdx).toBeGreaterThanOrEqual(0);
+      const upsert = ops.slice(posIdx + 1).find((o) => o.type === "upsertStyleTag");
+      expect(upsert).toBeTruthy();
+      expect(upsert.id).toBe("component-instance-css-id1");
+      expect(String(upsert.cssText || "")).toContain("left:17px");
+      expect(String(upsert.cssText || "")).toContain("top:29px");
+      expect(ops.slice(posIdx + 1).some((o) => o.type === "commit")).toBe(true);
+    });
+
 });

--- a/tests/unit/plugins/canvas-selection-plugin-stagecrew.test.ts
+++ b/tests/unit/plugins/canvas-selection-plugin-stagecrew.test.ts
@@ -1,0 +1,64 @@
+import { loadRenderXPlugin } from "../../utils/renderx-plugin-loader";
+
+/**
+ * Red: Selection plugin must perform StageCrew transactions to show/hide selection
+ * Expectations:
+ * - handleSelect: begins a beat and updates the selected element to add a selection class
+ * - handleFinalize (when clearSelection===true): begins a beat and removes the selection class
+ */
+
+describe("Canvas Selection Plugin - StageCrew transactions", () => {
+  const plugin = loadRenderXPlugin("RenderX/public/plugins/canvas-selection-plugin/index.js");
+
+  function makeCtx() {
+    const calls: any[] = [];
+    const stageCrew = {
+      beginBeat: (corrId: string, meta: any) => {
+        const tx = {
+          update: (selector: string, payload: any) => {
+            calls.push({ kind: "update", selector, payload, corrId, meta });
+            return tx;
+          },
+          upsertStyleTag: (id: string, cssText: string) => {
+            calls.push({ kind: "style", id, cssText, corrId, meta });
+            return tx;
+          },
+          commit: () => {
+            calls.push({ kind: "commit", corrId, meta });
+          },
+        };
+        calls.push({ kind: "begin", corrId, meta });
+        return tx;
+      },
+    };
+    return { ctx: { stageCrew, sequence: plugin.sequence, payload: {} as any }, calls };
+  }
+
+  test("handleSelect adds selection class via StageCrew", () => {
+    const { ctx, calls } = makeCtx();
+    const elementId = "id-123";
+
+    plugin.handlers.handleSelect({ elementId }, ctx as any);
+
+    // Must begin a beat and perform an update on #<id>
+    const begin = calls.find((c) => c.kind === "begin");
+    expect(begin).toBeTruthy();
+    const upd = calls.find((c) => c.kind === "update" && c.selector === `#${elementId}`);
+    expect(upd).toBeTruthy();
+    expect(upd.payload?.classes?.add || []).toContain("rx-comp-selected");
+    const committed = calls.some((c) => c.kind === "commit");
+    expect(committed).toBe(true);
+  });
+
+  test("handleFinalize removes selection class when clearSelection===true", () => {
+    const { ctx, calls } = makeCtx();
+    const elementId = "id-123";
+
+    plugin.handlers.handleFinalize({ elementId, clearSelection: true }, ctx as any);
+
+    const upd = calls.find((c) => c.kind === "update" && c.selector === `#${elementId}`);
+    expect(upd).toBeTruthy();
+    expect(upd.payload?.classes?.remove || []).toContain("rx-comp-selected");
+  });
+});
+

--- a/tests/unit/plugins/canvas-ui-plugin-drag-no-direct-dom.test.ts
+++ b/tests/unit/plugins/canvas-ui-plugin-drag-no-direct-dom.test.ts
@@ -1,0 +1,76 @@
+import { loadRenderXPlugin } from "../../utils/renderx-plugin-loader";
+
+/**
+ * TDD Red: Canvas UI drag handlers must not directly mutate DOM (classList/style)
+ * They should rely on StageCrew via conductor.play -> canvas-drag-plugin handlers
+ */
+
+describe("Canvas UI drag handlers - no direct DOM mutations", () => {
+  function makeNode() {
+    return {
+      id: "rx-dd-no-dom",
+      cssClass: "rx-dd-no-dom",
+      type: "button",
+      position: { x: 0, y: 0 },
+      component: {
+        metadata: { name: "Button", type: "button" },
+        ui: { template: '<button class="rx-button">OK</button>', styles: { css: ".rx-button{color:#000}" } },
+        integration: { canvasIntegration: { defaultWidth: 100, defaultHeight: 30 } },
+      },
+    } as any;
+  }
+
+  test("onPointerDown/up should not call classList.add/remove or write style properties directly", async () => {
+    // Reset window and minimal globals
+    (global as any).window = (global as any).window || {};
+    (global as any).window.renderxCommunicationSystem = { conductor: {} } as any;
+
+    // Stub React used by the UI plugin
+    const created: any[] = [];
+    (global as any).window.React = {
+      createElement: (type: any, props: any, ...children: any[]) => {
+        const el = { type, props, children }; created.push(el); return el;
+      },
+      useEffect: (fn: any) => fn(),
+      useState: (init: any) => [init, () => {}],
+      cloneElement: (el: any, p?: any) => ({ ...el, props: { ...(el.props||{}), ...(p||{}) } }),
+    } as any;
+
+    const plugin: any = loadRenderXPlugin("RenderX/public/plugins/canvas-ui-plugin/index.js");
+    const node = makeNode();
+
+    // Render element to get drag handlers
+    const el = plugin.renderCanvasNode(node);
+
+    // Build a currentTarget stub that records classList and style writes
+    const classList = { add: jest.fn(), remove: jest.fn() };
+
+    const style: any = {};
+    const touchActionSetter = jest.fn();
+    const willChangeSetter = jest.fn();
+    const transformSetter = jest.fn();
+    Object.defineProperty(style, "touchAction", { set: touchActionSetter, get: () => "", configurable: true });
+    Object.defineProperty(style, "willChange", { set: willChangeSetter, get: () => "", configurable: true });
+    Object.defineProperty(style, "transform", { set: transformSetter, get: () => "", configurable: true });
+
+    const currentTarget: any = { classList, style };
+    const target: any = { setPointerCapture: jest.fn(), releasePointerCapture: jest.fn() };
+
+    // Start drag (down)
+    el.props.onPointerDown({ currentTarget, clientX: 1, clientY: 2, pointerId: 1, target, stopPropagation(){} });
+
+    // Move a bit (not asserting here; focus on direct DOM writes)
+    el.props.onPointerMove({ currentTarget, clientX: 5, clientY: 7 });
+
+    // End drag (up)
+    el.props.onPointerUp({ currentTarget, clientX: 5, clientY: 7, pointerId: 1, target });
+
+    // Assert: NO direct DOM mutations invoked by UI drag handlers
+    expect(classList.add).not.toHaveBeenCalled();
+    expect(classList.remove).not.toHaveBeenCalled();
+    expect(touchActionSetter).not.toHaveBeenCalled();
+    expect(willChangeSetter).not.toHaveBeenCalled();
+    expect(transformSetter).not.toHaveBeenCalled();
+  });
+});
+

--- a/tests/unit/plugins/canvas-ui-plugin-overlay-visibility-and-cursor.test.js
+++ b/tests/unit/plugins/canvas-ui-plugin-overlay-visibility-and-cursor.test.js
@@ -7,10 +7,103 @@ describe("Canvas UI overlay visibility during drag and cursor policy", () => {
     while (document.head.firstChild)
       document.head.removeChild(document.head.firstChild);
 
-    // Conductor
+    // Conductor + StageCrew DOM-applier routing
     const eventBus = TestEnvironment.createEventBus();
     const conductor = TestEnvironment.createMusicalConductor(eventBus);
     global.window = global.window || {};
+
+    const dragPlugin = loadRenderXPlugin(
+      "RenderX/public/plugins/canvas-drag-plugin/index.js"
+    );
+    const beginBeat = (corrId, meta) => {
+      const txn = {
+        update: (selector, payload) => {
+          try {
+            let el = null;
+            if (selector && selector.startsWith("#")) {
+              const id = selector.slice(1);
+              el =
+                document.getElementById(id) ||
+                (window.__rx_drag &&
+                  window.__rx_drag[id] &&
+                  window.__rx_drag[id].el) ||
+                null;
+            }
+            if (el) {
+              if (payload?.classes?.add)
+                payload.classes.add.forEach((c) => el.classList.add(c));
+              if (payload?.classes?.remove)
+                payload.classes.remove.forEach((c) => el.classList.remove(c));
+              if (payload?.style)
+                Object.entries(payload.style).forEach(([k, v]) => {
+                  el.style[k] = v;
+                });
+            }
+          } catch {}
+          return txn;
+        },
+        upsertStyleTag: (id, cssText) => {
+          try {
+            let tag = document.getElementById(id);
+            if (!tag) {
+              tag = document.createElement("style");
+              tag.id = id;
+              document.head.appendChild(tag);
+            }
+            tag.textContent = String(cssText || "");
+          } catch {}
+          return txn;
+        },
+        commit: () => {},
+      };
+      return txn;
+    };
+
+    conductor.play = jest.fn((_pluginId, seqId, payload) => {
+      if (seqId !== "Canvas.component-drag-symphony") return;
+      const ctx = {
+        payload: conductor.__ctxPayload || {},
+        stageCrew: { beginBeat },
+        sequence: dragPlugin.sequence,
+      };
+      const ev = payload?.event;
+      if (ev === "canvas:element:hover:enter") {
+        dragPlugin.handlers.handleHoverEnter(
+          { elementId: payload.elementId },
+          ctx
+        );
+      } else if (ev === "canvas:element:hover:leave") {
+        dragPlugin.handlers.handleHoverLeave(
+          { elementId: payload.elementId },
+          ctx
+        );
+      } else if (ev === "canvas:element:drag:start") {
+        const res = dragPlugin.handlers.handleDragStart(
+          { elementId: payload.elementId, origin: payload.origin },
+          ctx
+        );
+        conductor.__ctxPayload = { ...(ctx.payload || {}), ...(res || {}) };
+      } else if (ev === "canvas:element:moved") {
+        const res = dragPlugin.handlers.handleDragMove(
+          { elementId: payload.elementId, delta: payload.delta },
+          { ...ctx, payload: conductor.__ctxPayload || {} }
+        );
+        conductor.__ctxPayload = {
+          ...(conductor.__ctxPayload || {}),
+          ...(res || {}),
+        };
+      } else if (ev === "canvas:element:drag:end") {
+        dragPlugin.handlers.handleDragEnd(
+          {
+            elementId: payload.elementId,
+            position: payload.position,
+            instanceClass: payload.instanceClass,
+          },
+          { ...ctx, payload: conductor.__ctxPayload || {} }
+        );
+      }
+    });
+
     window.renderxCommunicationSystem = { conductor };
 
     // React stub collects created elements
@@ -59,7 +152,10 @@ describe("Canvas UI overlay visibility during drag and cursor policy", () => {
 
     // Real DOM element for style transform (cursor class is applied on hover enter, not at initial render)
     const domEl = document.createElement("div");
-    // Simulate hover to apply rx-comp-draggable
+    // Ensure StageCrew selector (#id) can resolve this element
+    domEl.id = node.id;
+    document.body.appendChild(domEl);
+    // Simulate hover to apply rx-comp-draggable via StageCrew
     el.props.onPointerEnter({ currentTarget: domEl });
     expect(domEl.classList.contains("rx-comp-draggable")).toBe(true);
 
@@ -90,6 +186,7 @@ describe("Canvas UI overlay visibility during drag and cursor policy", () => {
       clientX: 120,
       clientY: 120,
     });
+    await new Promise((r) => setTimeout(r, 20));
 
     // End drag -> overlay visibility cleared and overlay shown
     el.props.onPointerUp({

--- a/tests/unit/policy/stagecrew-scope-overlay-instance.test.ts
+++ b/tests/unit/policy/stagecrew-scope-overlay-instance.test.ts
@@ -1,0 +1,79 @@
+import { loadRenderXPlugin } from "../../utils/renderx-plugin-loader";
+import { TestEnvironment } from "../../utils/test-helpers";
+
+/**
+ * Policy (Red): Overlay StageCrew operations must occur within play() sequence handlers
+ * - Any beginBeat emitted by overlayEnsure* must carry sequenceId in meta
+ * Expected to FAIL currently because Canvas UI calls overlayEnsure* from UI code without handler context
+ */
+
+describe("Policy: Overlay StageCrew ops must be inside play() handlers (with sequenceId)", () => {
+  test("CanvasPage render (selected node) → overlayEnsure* beginBeat carries sequenceId", async () => {
+    // Conductor + StageCrew recorder
+    const eventBus = TestEnvironment.createEventBus();
+    const conductor = TestEnvironment.createMusicalConductor(eventBus as any);
+
+    const ops: any[] = [];
+    const beginBeat = jest.fn((corrId: string, meta: any) => {
+      const txn: any = {
+        upsertStyleTag: (id: string, cssText: string) => {
+          ops.push({ type: "upsertStyleTag", id, cssText, meta });
+          return txn;
+        },
+        update: (selector: string, payload: any) => {
+          ops.push({ type: "update", selector, payload, meta });
+          return txn;
+        },
+        commit: () => {
+          ops.push({ type: "commit", meta });
+        },
+      };
+      ops.push({ type: "beginBeat", corrId, meta });
+      return txn;
+    });
+
+    (global as any).window = (global as any).window || {};
+    (global as any).window.renderxCommunicationSystem = { conductor, stageCrew: { beginBeat }, __ops: ops } as any;
+
+    // React stub
+    const created: any[] = [];
+    (global as any).window.React = {
+      createElement: (type: any, props: any, ...children: any[]) => {
+        created.push({ type, props, children });
+        return { type, props, children };
+      },
+      useEffect: (fn: any) => fn(),
+      useState: (init: any) => [init, () => {}],
+      cloneElement: (el: any, p?: any) => ({ ...el, props: { ...(el.props || {}), ...(p || {}) } }),
+    } as any;
+
+    // Load UI and render a node with selection so overlay is ensured via StageCrew
+    const ui: any = loadRenderXPlugin("RenderX/public/plugins/canvas-ui-plugin/index.js");
+    const node = {
+      id: "rx-overlay-scope-1",
+      cssClass: "rx-overlay-scope-1",
+      type: "button",
+      position: { x: 25, y: 35 },
+      component: {
+        metadata: { name: "Button", type: "button" },
+        ui: { template: '<button class="rx-button">OK</button>', styles: { css: ".rx-button{color:#000}" } },
+        integration: { canvasIntegration: { defaultWidth: 110, defaultHeight: 32 } },
+      },
+    };
+
+    created.length = 0;
+    ui.CanvasPage({ nodes: [node], selectedId: node.id });
+
+    // Find overlay-related StageCrew beginBeats (overlayStyles from canvas-ui-plugin)
+    const overlayBegins = ops.filter(
+      (o) => o.type === "beginBeat" && o.meta?.handlerName === "overlayStyles" && o.meta?.plugin === "canvas-ui-plugin"
+    );
+    expect(overlayBegins.length).toBeGreaterThan(0);
+
+    // POLICY: every overlay beginBeat must have a sequenceId (i.e., originated inside a play() handler)
+    overlayBegins.forEach((b) => {
+      expect(b.meta?.sequenceId).toBeTruthy(); // Expected to FAIL today
+    });
+  });
+});
+

--- a/tests/unit/policy/stagecrew-scope-overlay-no-ui-origin.test.ts
+++ b/tests/unit/policy/stagecrew-scope-overlay-no-ui-origin.test.ts
@@ -1,0 +1,65 @@
+import { loadRenderXPlugin } from "../../utils/renderx-plugin-loader";
+import { TestEnvironment } from "../../utils/test-helpers";
+
+/**
+ * Red: Overlay StageCrew must not originate from Canvas UI plugin code
+ * Expect no beginBeat with meta.plugin === 'canvas-ui-plugin' && handlerName === 'overlayStyles'
+ */
+
+describe("Policy: Overlay StageCrew must not originate from Canvas UI plugin", () => {
+  test("selection click flow emits no UI-origin overlay beginBeat", async () => {
+    // Conductor + mount selection plugin
+    const eventBus = TestEnvironment.createEventBus();
+    const conductor = TestEnvironment.createMusicalConductor(eventBus as any);
+    const selection: any = loadRenderXPlugin("RenderX/public/plugins/canvas-selection-plugin/index.js");
+    await conductor.mount(selection.sequence, selection.handlers, selection.sequence.id);
+
+    const ops: any[] = [];
+    const beginBeat = jest.fn((corrId: string, meta: any) => {
+      const txn: any = {
+        upsertStyleTag: (id: string, cssText: string) => { ops.push({ type: "upsertStyleTag", id, cssText, meta }); return txn; },
+        update: (selector: string, payload: any) => { ops.push({ type: "update", selector, payload, meta }); return txn; },
+        commit: () => { ops.push({ type: "commit", meta }); },
+      };
+      ops.push({ type: "beginBeat", corrId, meta });
+      return txn;
+    });
+    (global as any).window = (global as any).window || {};
+    (global as any).window.renderxCommunicationSystem = { conductor, stageCrew: { beginBeat }, __ops: ops } as any;
+
+    // React stub
+    const created: any[] = [];
+    (global as any).window.React = {
+      createElement: (type: any, props: any, ...children: any[]) => { created.push({ type, props, children }); return { type, props, children }; },
+      useEffect: (fn: any) => fn(),
+      useState: (init: any) => [init, () => {}],
+      cloneElement: (el: any, p?: any) => ({ ...el, props: { ...(el.props||{}), ...(p||{}) } }),
+    } as any;
+
+    // UI + click handler
+    const ui: any = loadRenderXPlugin("RenderX/public/plugins/canvas-ui-plugin/index.js");
+    const clickHandlers: any = loadRenderXPlugin("RenderX/public/plugins/canvas-ui-plugin/handlers/select.js");
+
+    const node = {
+      id: "rx-overlay-policy-ui-origin",
+      cssClass: "rx-overlay-policy-ui-origin",
+      type: "button",
+      position: { x: 15, y: 25 },
+      component: {
+        metadata: { name: "Button", type: "button" },
+        ui: { template: '<button class="rx-button">OK</button>', styles: { css: ".rx-button{color:#000}" } },
+        integration: { canvasIntegration: { defaultWidth: 90, defaultHeight: 28 } },
+      },
+    };
+
+    // Render page and click selection
+    ui.CanvasPage({ nodes: [node], selectedId: node.id });
+    const click = clickHandlers.onElementClick(node);
+    await click({ stopPropagation() {} });
+
+    // Assert: no UI-origin overlay beginBeat
+    const uiOverlayBegins = ops.filter((o) => o.type === "beginBeat" && o.meta?.handlerName === "overlayStyles" && o.meta?.plugin === "canvas-ui-plugin");
+    expect(uiOverlayBegins.length).toBe(0);
+  });
+});
+

--- a/tests/unit/policy/stagecrew-scope-overlay-selection-click.test.ts
+++ b/tests/unit/policy/stagecrew-scope-overlay-selection-click.test.ts
@@ -1,0 +1,76 @@
+import { loadRenderXPlugin } from "../../utils/renderx-plugin-loader";
+import { TestEnvironment } from "../../utils/test-helpers";
+
+/**
+ * Policy (Red): Overlay StageCrew operations must occur within play() sequence handlers
+ * - Selection click path should result in overlayEnsure* beginBeat having sequenceId
+ * Expected to FAIL currently because Canvas UI calls overlayEnsure* from UI code without handler context
+ */
+
+describe("Policy: Overlay StageCrew ops must be inside play() handlers (selection click flow)", () => {
+  test("onElementClick -> selection -> overlayEnsure* beginBeat carries sequenceId", async () => {
+    const eventBus = TestEnvironment.createEventBus();
+    const conductor = TestEnvironment.createMusicalConductor(eventBus as any);
+
+    // Mount selection plugin so UI click plays the sequence
+    const selection: any = loadRenderXPlugin("RenderX/public/plugins/canvas-selection-plugin/index.js");
+    await conductor.mount(selection.sequence, selection.handlers, selection.sequence.id);
+
+    const ops: any[] = [];
+    const beginBeat = jest.fn((corrId: string, meta: any) => {
+      const txn: any = {
+        upsertStyleTag: (id: string, cssText: string) => { ops.push({ type: "upsertStyleTag", id, cssText, meta }); return txn; },
+        update: (selector: string, payload: any) => { ops.push({ type: "update", selector, payload, meta }); return txn; },
+        commit: () => { ops.push({ type: "commit", meta }); },
+      };
+      ops.push({ type: "beginBeat", corrId, meta });
+      return txn;
+    });
+
+    (global as any).window = (global as any).window || {};
+    (global as any).window.renderxCommunicationSystem = { conductor, stageCrew: { beginBeat }, __ops: ops } as any;
+
+    // React stub
+    const created: any[] = [];
+    (global as any).window.React = {
+      createElement: (type: any, props: any, ...children: any[]) => { created.push({ type, props, children }); return { type, props, children }; },
+      useEffect: (fn: any) => fn(),
+      useState: (init: any) => [init, () => {}],
+      cloneElement: (el: any, p?: any) => ({ ...el, props: { ...(el.props||{}), ...(p||{}) } }),
+    } as any;
+
+    // UI
+    const ui: any = loadRenderXPlugin("RenderX/public/plugins/canvas-ui-plugin/index.js");
+    const clickHandlers: any = loadRenderXPlugin("RenderX/public/plugins/canvas-ui-plugin/handlers/select.js");
+    const node = {
+      id: "rx-overlay-scope-2",
+      cssClass: "rx-overlay-scope-2",
+      type: "button",
+      position: { x: 10, y: 20 },
+      component: {
+        metadata: { name: "Button", type: "button" },
+        ui: { template: '<button class="rx-button">OK</button>', styles: { css: ".rx-button{color:#000}" } },
+        integration: { canvasIntegration: { defaultWidth: 100, defaultHeight: 30 } },
+      },
+    };
+
+    // Render CanvasPage with node so selection shows overlay
+    ui.CanvasPage({ nodes: [node], selectedId: node.id });
+
+    // Simulate click selection flow
+    const click = clickHandlers.onElementClick(node);
+    await click({ stopPropagation() {} });
+
+    // Find overlay beginBeats from UI overlay ensures
+    const overlayBegins = ops.filter(
+      (o) => o.type === "beginBeat" && o.meta?.handlerName === "overlayStyles" && o.meta?.plugin === "canvas-ui-plugin"
+    );
+    expect(overlayBegins.length).toBeGreaterThan(0);
+
+    // POLICY: must carry sequenceId (scope of play handler)
+    overlayBegins.forEach((b) => {
+      expect(b.meta?.sequenceId).toBeTruthy(); // Expected to FAIL today
+    });
+  });
+});
+


### PR DESCRIPTION
Closes #21

Summary
- Move all StageCrew beginBeat/update/commit operations for drag into Canvas.component-drag-symphony handlers (handleDragStart/handleDragMove/handleDragEnd)
- Thin canvas-ui-plugin drag listeners to only coordinate pointer events and emit conductor.play with event hints; minimal local class toggles remain for hover/active affordance
- Ensure handlers apply:
  - start: remove rx-comp-draggable, add rx-comp-grabbing; touchAction: none; willChange: transform
  - move: translate3d(dx, dy, 0) with rAF-coalesced frames
  - end: clear transform/willChange/touchAction; restore classes; upsert per-instance position CSS (component-instance-css-<id>)
- Tests: add handler-level StageCrew assertions and adapt UI contract test to route play() to drag handlers so StageCrew ops originate from handlers

Why
- Aligns with Musical Conductor + StageCrew pattern (see theme-management-plugin)
- Avoids direct DOM StageCrew mutations in UI listeners; improves testability and separation of concerns

Notes
- conductor.play signature unchanged; event names are carried in payload for internal routing
- If desired we can follow-up to extract shared CSS text builder for position to a common helper

TDD
- Red: extend/adjust tests to assert handler StageCrew behavior
- Green: implement handler StageCrew logic; thin UI drag
- Refactor: minimal; ready for review


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author